### PR TITLE
Replace error handling with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ all = []
 [dependencies]
 hyper = "0.13"
 http = "0.2"
-regex = "1.3"
-lazy_static = "1.4"
-percent-encoding = "2.1"
+regex = "1"
+lazy_static = "1"
+percent-encoding = "2"
+thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,5 +1,6 @@
 use hyper::{Body, Request, Response, Server, StatusCode};
 use routerify::{Router, RouterService};
+use std::error::Error;
 use std::io;
 use std::net::SocketAddr;
 
@@ -13,13 +14,22 @@ async fn about_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
     Ok(Response::new(Body::from("About page")))
 }
 
+fn format_cause_chain(err: impl Error) -> String {
+    let mut lines = vec![format!("error: {}", err)];
+    let mut source = err.source();
+    while let Some(src) = source {
+        lines.push(format!("  caused by: {}", src));
+        source = src.source();
+    }
+    lines.join("\n")
+}
+
 // Define an error handler function which will accept the `routerify::Error`
 // and generates an appropriate response.
 async fn error_handler(err: routerify::Error) -> Response<Body> {
-    eprintln!("{}", err);
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
-        .body(Body::from(format!("Something went wrong: {}", err)))
+        .body(Body::from(format_cause_chain(err)))
         .unwrap()
 }
 

--- a/examples/test-with-heavy-loads.rs
+++ b/examples/test-with-heavy-loads.rs
@@ -14,7 +14,7 @@ fn router() -> Router<Body, routerify::Error> {
             .unwrap(),
         );
 
-        builder = builder.get(format!("/abc-{}", i), move |req| async move {
+        builder = builder.get(format!("/abc-{}", i), move |_req| async move {
             // println!("Route: {}, params: {:?}", format!("/abc-{}", i), req.params());
             Ok(Response::new(Body::from(format!("/abc-{}", i))))
         });

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -25,7 +25,10 @@ pub async fn home_handler(req: Request<Body>) -> Result<Response<Body>, routerif
     println!("Route Data: {}", data);
     println!("Route Data2: {:?}", req.data::<u32>());
 
-    Err(routerify::Error::HandleRequest("Error".into()))
+    Err(routerify::Error::HandleRequest(
+        "Error".into(),
+        "/some/fake/path".into(),
+    ))
 }
 
 async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -2,8 +2,6 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use routerify::prelude::*;
 use routerify::{Middleware, RequestInfo, Router, RouterService};
 use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
 pub struct State(pub i32);
 
@@ -27,8 +25,7 @@ pub async fn home_handler(req: Request<Body>) -> Result<Response<Body>, routerif
     println!("Route Data: {}", data);
     println!("Route Data2: {:?}", req.data::<u32>());
 
-    // Ok(Response::new(Body::from(format!("New counter: {}\n", data))))
-    Err(routerify::Error::new("Error"))
+    Err(routerify::Error::HandleRequest("Error".into()))
 }
 
 async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+edition = "2018"
 max_width = 120
 tab_spaces = 4

--- a/src/data_map/scoped.rs
+++ b/src/data_map/scoped.rs
@@ -1,5 +1,4 @@
 use crate::data_map::{DataMap, SharedDataMap};
-use crate::prelude::*;
 use crate::regex_generator::generate_exact_match_regex;
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -16,8 +15,7 @@ pub(crate) struct ScopedDataMap {
 impl ScopedDataMap {
     pub fn new<P: Into<String>>(path: P, data_map: Arc<DataMap>) -> crate::Result<ScopedDataMap> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())
-            .context("Could not create an exact match regex for the scoped data map path")?;
+        let (re, _) = generate_exact_match_regex(path.as_str())?;
 
         Ok(ScopedDataMap {
             path,

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,15 +13,18 @@ pub enum Error {
     #[error("Could not create an exact match regex for the route path")]
     GeneratePrefixMatchRegex(#[source] regex::Error),
 
-    #[error("One of the pre middlewares couldn't process the request")]
-    ProcessPreMiddleware(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-
     #[error("No handlers added to handle non-existent routes. Tips: Please add an '.any' route at the bottom to handle any routes.")]
     HandleNonExistentRoute,
 
-    #[error("One of the post middlewares couldn't process the response")]
-    ProcessPostMiddleware(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("One of the routes couldn't handle a pre-middleware request")]
+    HandlePreMiddlewareRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    #[error("One of the routes couldn't handle the request")]
-    HandleRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("One of the routes couldn't handle the request for target: {1}")]
+    HandleRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>, String),
+
+    #[error("One of the routes couldn't handle a pre-middleware request")]
+    HandlePostMiddlewareWithoutInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("One of the post middlewares couldn't process the response")]
+    HandlePostMiddlewareWithInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,24 +7,24 @@ pub enum Error {
     #[error("Couldn't create router RegexSet")]
     CreateRouterRegexSet(#[source] regex::Error),
 
-    #[error("Could not create an exact match regex for the route path")]
-    GenerateExactMatchRegex(#[source] regex::Error),
+    #[error("Could not create an exact match regex for the route path: {1}")]
+    GenerateExactMatchRegex(#[source] regex::Error, String),
 
-    #[error("Could not create an exact match regex for the route path")]
-    GeneratePrefixMatchRegex(#[source] regex::Error),
+    #[error("Could not create an exact match regex for the route path: {1}")]
+    GeneratePrefixMatchRegex(#[source] regex::Error, String),
 
     #[error("No handlers added to handle non-existent routes. Tips: Please add an '.any' route at the bottom to handle any routes.")]
     HandleNonExistentRoute,
 
-    #[error("One of the routes couldn't handle a pre-middleware request")]
+    #[error("A route was unable to handle the pre middleware request")]
     HandlePreMiddlewareRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    #[error("One of the routes couldn't handle the request for target: {1}")]
+    #[error("A route was unable to handle the request for target: {1}")]
     HandleRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>, String),
 
-    #[error("One of the routes couldn't handle a pre-middleware request")]
+    #[error("One of the post middlewares (without info) couldn't process the response")]
     HandlePostMiddlewareWithoutInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    #[error("One of the post middlewares couldn't process the response")]
+    #[error("One of the post middlewares (with info) couldn't process the response")]
     HandlePostMiddlewareWithInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,5 @@
-use crate::prelude::*;
 use crate::types::RequestMeta;
+use crate::Error;
 use http::Extensions;
 use percent_encoding::percent_decode_str;
 
@@ -14,7 +14,7 @@ pub(crate) fn update_req_meta_in_extensions(ext: &mut Extensions, new_req_meta: 
 pub(crate) fn percent_decode_request_path(val: &str) -> crate::Result<String> {
     percent_decode_str(val)
         .decode_utf8()
-        .context("Couldn't decode the request path as UTF8")
+        .map_err(Error::DecodeRequestPath)
         .map(|val| val.to_string())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,7 +762,6 @@
 
 pub use self::error::Error;
 #[doc(hidden)]
-pub use self::error::{ErrorExt, ResultExt};
 pub use self::middleware::{Middleware, PostMiddleware, PreMiddleware};
 pub use self::route::Route;
 pub use self::router::{Router, RouterBuilder};

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -142,11 +142,11 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         match handler {
             Handler::WithoutInfo(ref mut handler) => Pin::from(handler(res))
                 .await
-                .map_err(|e| Error::HandleRequest(e.into())),
+                .map_err(|e| Error::HandlePostMiddlewareWithoutInfoRequest(e.into())),
             Handler::WithInfo(ref mut handler) => {
                 Pin::from(handler(res, req_info.expect("No RequestInfo is provided")))
                     .await
-                    .map_err(|e| Error::HandleRequest(e.into()))
+                    .map_err(|e| Error::HandlePostMiddlewareWithInfoRequest(e.into()))
             }
         }
     }

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -1,6 +1,6 @@
-use crate::prelude::*;
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::RequestInfo;
+use crate::Error;
 use hyper::{body::HttpBody, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -43,8 +43,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         handler: Handler<B, E>,
     ) -> crate::Result<PostMiddleware<B, E>> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())
-            .context("Could not create an exact match regex for the post middleware path")?;
+        let (re, _) = generate_exact_match_regex(path.as_str())?;
 
         Ok(PostMiddleware {
             path,
@@ -141,11 +140,13 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             .expect("A router can not be used after mounting into another router");
 
         match handler {
-            Handler::WithoutInfo(ref mut handler) => Pin::from(handler(res)).await.wrap(),
+            Handler::WithoutInfo(ref mut handler) => Pin::from(handler(res))
+                .await
+                .map_err(|e| Error::HandleRequest(e.into())),
             Handler::WithInfo(ref mut handler) => {
                 Pin::from(handler(res, req_info.expect("No RequestInfo is provided")))
                     .await
-                    .wrap()
+                    .map_err(|e| Error::HandleRequest(e.into()))
             }
         }
     }

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -73,7 +73,7 @@ impl<E: std::error::Error + Send + Sync + Unpin + 'static> PreMiddleware<E> {
 
         Pin::from(handler(req))
             .await
-            .map_err(|e| Error::HandleRequest(e.into()))
+            .map_err(|e| Error::HandlePreMiddlewareRequest(e.into()))
     }
 }
 

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -1,5 +1,5 @@
-use crate::prelude::*;
 use crate::regex_generator::generate_exact_match_regex;
+use crate::Error;
 use hyper::Request;
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -28,8 +28,7 @@ impl<E: std::error::Error + Send + Sync + Unpin + 'static> PreMiddleware<E> {
         handler: Handler<E>,
     ) -> crate::Result<PreMiddleware<E>> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())
-            .context("Could not create an exact match regex for the pre middleware path")?;
+        let (re, _) = generate_exact_match_regex(path.as_str())?;
 
         Ok(PreMiddleware {
             path,
@@ -72,7 +71,9 @@ impl<E: std::error::Error + Send + Sync + Unpin + 'static> PreMiddleware<E> {
             .as_mut()
             .expect("A router can not be used after mounting into another router");
 
-        Pin::from(handler(req)).await.wrap()
+        Pin::from(handler(req))
+            .await
+            .map_err(|e| Error::HandleRequest(e.into()))
     }
 }
 

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -1,3 +1,1 @@
 pub use crate::ext::RequestExt;
-#[allow(unused_imports)]
-pub(crate) use crate::{ErrorExt, ResultExt};

--- a/src/regex_generator/mod.rs
+++ b/src/regex_generator/mod.rs
@@ -6,9 +6,9 @@ lazy_static! {
     static ref PATH_PARAMS_RE: Regex = Regex::new(r"(?s)(?::([^/]+))|(?:\*)").unwrap();
 }
 
-fn generate_common_regex_str(path: &str) -> crate::Result<(String, Vec<String>)> {
+fn generate_common_regex_str(path: &str) -> (String, Vec<String>) {
     let mut regex_str = String::with_capacity(path.len());
-    let mut param_names: Vec<String> = Vec::new();
+    let mut param_names = Vec::new();
 
     let mut pos: usize = 0;
 
@@ -32,21 +32,21 @@ fn generate_common_regex_str(path: &str) -> crate::Result<(String, Vec<String>)>
     let left_over_path_s = &path[pos..];
     regex_str += &regex::escape(left_over_path_s);
 
-    Ok((regex_str, param_names))
+    (regex_str, param_names)
 }
 
 pub(crate) fn generate_exact_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
-    let (common_regex_str, params) = generate_common_regex_str(path)?;
+    let (common_regex_str, params) = generate_common_regex_str(path);
     let re_str = format!("{}{}{}", r"(?s)^", common_regex_str, "$");
-    let re = Regex::new(re_str.as_str()).map_err(Error::GenerateExactMatchRegex)?;
+    let re = Regex::new(re_str.as_str()).map_err(|e| Error::GenerateExactMatchRegex(e, path.into()))?;
     Ok((re, params))
 }
 
 #[allow(dead_code)]
 pub(crate) fn generate_prefix_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
-    let (common_regex_str, params) = generate_common_regex_str(path)?;
+    let (common_regex_str, params) = generate_common_regex_str(path);
     let re_str = format!("{}{}", r"(?s)^", common_regex_str);
-    let re = Regex::new(re_str.as_str()).map_err(Error::GeneratePrefixMatchRegex)?;
+    let re = Regex::new(re_str.as_str()).map_err(|e| Error::GeneratePrefixMatchRegex(e, path.into()))?;
     Ok((re, params))
 }
 
@@ -57,29 +57,29 @@ mod tests {
     #[test]
     fn test_generate_common_regex_str_normal() {
         let path = "/";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/".to_owned(), Vec::<String>::new()));
 
         let path = "/api/v1/services/get_ip";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/api/v1/services/get_ip".to_owned(), Vec::<String>::new()))
     }
 
     #[test]
     fn test_generate_common_regex_str_special_character() {
         let path = "/users/user-data/view";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/user\-data/view".to_owned(), Vec::<String>::new()))
     }
 
     #[test]
     fn test_generate_common_regex_str_params() {
         let path = "/users/:username/data";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/([^/]+)/data".to_owned(), vec!["username".to_owned()]));
 
         let path = "/users/:username/data/:attr/view";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(
             r,
             (
@@ -89,30 +89,30 @@ mod tests {
         );
 
         let path = "/users/:username";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/([^/]+)".to_owned(), vec!["username".to_owned()]));
 
         let path = ":username";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"([^/]+)".to_owned(), vec!["username".to_owned()]));
     }
 
     #[test]
     fn test_generate_common_regex_str_star_globe() {
         let path = "*";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"(.*)".to_owned(), vec!["*".to_owned()]));
 
         let path = "/users/*";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/(.*)".to_owned(), vec!["*".to_owned()]));
 
         let path = "/users/*/data";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/(.*)/data".to_owned(), vec!["*".to_owned()]));
 
         let path = "/users/*/data/*";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(
             r,
             (
@@ -122,7 +122,7 @@ mod tests {
         );
 
         let path = "/users/**";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/(.*)(.*)".to_owned(), vec!["*".to_owned(), "*".to_owned()]));
     }
 }

--- a/src/regex_generator/mod.rs
+++ b/src/regex_generator/mod.rs
@@ -1,9 +1,9 @@
-use crate::prelude::*;
+use crate::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {
-    static ref PATH_PARAMS_RE: Regex = { Regex::new(r"(?s)(?::([^/]+))|(?:\*)").unwrap() };
+    static ref PATH_PARAMS_RE: Regex = Regex::new(r"(?s)(?::([^/]+))|(?:\*)").unwrap();
 }
 
 fn generate_common_regex_str(path: &str) -> crate::Result<(String, Vec<String>)> {
@@ -38,7 +38,7 @@ fn generate_common_regex_str(path: &str) -> crate::Result<(String, Vec<String>)>
 pub(crate) fn generate_exact_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
     let (common_regex_str, params) = generate_common_regex_str(path)?;
     let re_str = format!("{}{}{}", r"(?s)^", common_regex_str, "$");
-    let re = Regex::new(re_str.as_str()).wrap()?;
+    let re = Regex::new(re_str.as_str()).map_err(Error::GenerateExactMatchRegex)?;
     Ok((re, params))
 }
 
@@ -46,7 +46,7 @@ pub(crate) fn generate_exact_match_regex(path: &str) -> crate::Result<(Regex, Ve
 pub(crate) fn generate_prefix_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
     let (common_regex_str, params) = generate_common_regex_str(path)?;
     let re_str = format!("{}{}", r"(?s)^", common_regex_str);
-    let re = Regex::new(re_str.as_str()).wrap()?;
+    let re = Regex::new(re_str.as_str()).map_err(Error::GeneratePrefixMatchRegex)?;
     Ok((re, params))
 }
 

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -1,7 +1,7 @@
 use crate::helpers;
-use crate::prelude::*;
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::{RequestMeta, RouteParams};
+use crate::Error;
 use hyper::{body::HttpBody, Method, Request, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -60,8 +60,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         handler: Handler<B, E>,
     ) -> crate::Result<Route<B, E>> {
         let path = path.into();
-        let (re, params) = generate_exact_match_regex(path.as_str())
-            .context("Could not create an exact match regex for the route path")?;
+        let (re, params) = generate_exact_match_regex(path.as_str())?;
 
         Ok(Route {
             path,
@@ -98,7 +97,9 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             .as_mut()
             .expect("A router can not be used after mounting into another router");
 
-        Pin::from(handler(req)).await.wrap()
+        Pin::from(handler(req))
+            .await
+            .map_err(|e| Error::HandleRequest(e.into()))
     }
 
     fn push_req_meta(&self, target_path: &str, req: &mut Request<hyper::Body>) -> crate::Result<()> {

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -99,7 +99,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
 
         Pin::from(handler(req))
             .await
-            .map_err(|e| Error::HandleRequest(e.into()))
+            .map_err(|e| Error::HandleRequest(e.into(), target_path.into()))
     }
 
     fn push_req_meta(&self, target_path: &str, req: &mut Request<hyper::Body>) -> crate::Result<()> {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -178,10 +178,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         for idx in matched_pre_middleware_idxs {
             let pre_middleware = &mut self.pre_middlewares[idx];
 
-            transformed_req = pre_middleware
-                .process(transformed_req)
-                .await
-                .map_err(|e| Error::ProcessPreMiddleware(e.into()))?;
+            transformed_req = pre_middleware.process(transformed_req).await?;
         }
 
         let mut resp = None;
@@ -189,10 +186,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             let route = &mut self.routes[idx];
 
             if route.is_match_method(transformed_req.method()) {
-                let route_resp_res = route
-                    .process(target_path, transformed_req)
-                    .await
-                    .map_err(|e| Error::HandleRequest(e.into()));
+                let route_resp_res = route.process(target_path, transformed_req).await;
 
                 let route_resp = match route_resp_res {
                     Ok(route_resp) => route_resp,
@@ -217,11 +211,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         let mut transformed_res = resp.unwrap();
         for idx in matched_post_middleware_idxs {
             let post_middleware = &mut self.post_middlewares[idx];
-
-            transformed_res = post_middleware
-                .process(transformed_res, req_info.clone())
-                .await
-                .map_err(|e| Error::ProcessPostMiddleware(e.into()))?;
+            transformed_res = post_middleware.process(transformed_res, req_info.clone()).await?;
         }
 
         Ok(transformed_res)

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -1,5 +1,4 @@
 use crate::helpers;
-use crate::prelude::*;
 use crate::router::Router;
 use crate::types::{RequestInfo, RequestMeta};
 use hyper::{body::HttpBody, service::Service, Request, Response};
@@ -40,8 +39,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         let fut = async move {
             helpers::update_req_meta_in_extensions(req.extensions_mut(), RequestMeta::with_remote_addr(remote_addr));
 
-            let mut target_path = helpers::percent_decode_request_path(req.uri().path())
-                .context("Couldn't percent decode request path")?;
+            let mut target_path = helpers::percent_decode_request_path(req.uri().path())?;
 
             if target_path.as_bytes()[target_path.len() - 1] != b'/' {
                 target_path.push_str("/");


### PR DESCRIPTION
This PR replaces the current error handling mechanism with `thiserror`.

The primary goal is to enable users to construct a full error cause chain from
`routerify::Error` regardless of what underlying libraries users' handlers are
calling into.

I believe this closes #15.
