### PR TITLE
Replace error handling with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ all = []
 [dependencies]
 hyper = "0.13"
 http = "0.2"
-regex = "1.3"
-lazy_static = "1.4"
-percent-encoding = "2.1"
+regex = "1"
+lazy_static = "1"
+percent-encoding = "2"
+thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -13,13 +13,22 @@ async fn about_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
     Ok(Response::new(Body::from("About page")))
 }
 
+fn format_cause_chain(err: impl std::error::Error) -> String {
+    let mut lines = vec![format!("error: {}", err)];
+    let mut source = err.source();
+    while let Some(src) = source {
+        lines.push(format!("  caused by: {}", src));
+        source = src.source();
+    }
+    lines.join("\n")
+}
+
 // Define an error handler function which will accept the `routerify::Error`
 // and generates an appropriate response.
 async fn error_handler(err: routerify::Error) -> Response<Body> {
-    eprintln!("{}", err);
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
-        .body(Body::from(format!("Something went wrong: {}", err)))
+        .body(Body::from(format_cause_chain(err)))
         .unwrap()
 }
 

--- a/examples/test-with-heavy-loads.rs
+++ b/examples/test-with-heavy-loads.rs
@@ -14,7 +14,7 @@ fn router() -> Router<Body, routerify::Error> {
             .unwrap(),
         );
 
-        builder = builder.get(format!("/abc-{}", i), move |req| async move {
+        builder = builder.get(format!("/abc-{}", i), move |_req| async move {
             // println!("Route: {}, params: {:?}", format!("/abc-{}", i), req.params());
             Ok(Response::new(Body::from(format!("/abc-{}", i))))
         });

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -2,8 +2,6 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use routerify::prelude::*;
 use routerify::{Middleware, RequestInfo, Router, RouterService};
 use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
 pub struct State(pub i32);
 
@@ -27,8 +25,10 @@ pub async fn home_handler(req: Request<Body>) -> Result<Response<Body>, routerif
     println!("Route Data: {}", data);
     println!("Route Data2: {:?}", req.data::<u32>());
 
-    // Ok(Response::new(Body::from(format!("New counter: {}\n", data))))
-    Err(routerify::Error::new("Error"))
+    Err(routerify::Error::HandleRequest(
+        "Error".into(),
+        "/some/fake/path".into(),
+    ))
 }
 
 async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+edition = "2018"
 max_width = 120
 tab_spaces = 4

--- a/src/data_map/scoped.rs
+++ b/src/data_map/scoped.rs
@@ -1,5 +1,4 @@
 use crate::data_map::{DataMap, SharedDataMap};
-use crate::prelude::*;
 use crate::regex_generator::generate_exact_match_regex;
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -16,8 +15,7 @@ pub(crate) struct ScopedDataMap {
 impl ScopedDataMap {
     pub fn new<P: Into<String>>(path: P, data_map: Arc<DataMap>) -> crate::Result<ScopedDataMap> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())
-            .context("Could not create an exact match regex for the scoped data map path")?;
+        let (re, _) = generate_exact_match_regex(path.as_str())?;
 
         Ok(ScopedDataMap {
             path,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,70 +1,30 @@
-use std::fmt::{self, Debug, Display, Formatter};
-
 /// The error type used by the `Routerify` library.
-pub struct Error {
-    msg: String,
-}
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Couldn't decode the request path as UTF8")]
+    DecodeRequestPath(#[source] std::str::Utf8Error),
 
-impl Error {
-    /// Creates a new error instance with the specified message.
-    pub fn new<M: Into<String>>(msg: M) -> Self {
-        Error { msg: msg.into() }
-    }
+    #[error("Couldn't create router RegexSet")]
+    CreateRouterRegexSet(#[source] regex::Error),
 
-    /// Converts other error type to the `routerify::Error` type.
-    pub fn wrap<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
-        Error { msg: err.to_string() }
-    }
-}
+    #[error("Could not create an exact match regex for the route path: {1}")]
+    GenerateExactMatchRegex(#[source] regex::Error, String),
 
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "routerify::Error: {}", self.msg)
-    }
-}
+    #[error("Could not create an exact match regex for the route path: {1}")]
+    GeneratePrefixMatchRegex(#[source] regex::Error, String),
 
-impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "routerify::Error: {}", self.msg)
-    }
-}
+    #[error("No handlers added to handle non-existent routes. Tips: Please add an '.any' route at the bottom to handle any routes.")]
+    HandleNonExistentRoute,
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        self.msg.as_str()
-    }
-}
+    #[error("A route was unable to handle the pre middleware request")]
+    HandlePreMiddlewareRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-pub trait ErrorExt {
-    fn wrap(self) -> Error;
-    fn context<C: Display + Send + Sync + 'static>(self, ctx: C) -> Error;
-}
+    #[error("A route was unable to handle the request for target: {1}")]
+    HandleRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>, String),
 
-impl<E: std::error::Error + Send + Sync + 'static> ErrorExt for E {
-    fn wrap(self) -> Error {
-        Error { msg: self.to_string() }
-    }
+    #[error("One of the post middlewares (without info) couldn't process the response")]
+    HandlePostMiddlewareWithoutInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    fn context<C: Display + Send + Sync + 'static>(self, ctx: C) -> Error {
-        let msg = format!("{}: {}", ctx, self.to_string());
-        Error { msg }
-    }
-}
-
-pub trait ResultExt<T> {
-    fn wrap(self) -> Result<T, Error>;
-    fn context<C: Display + Send + Sync + 'static>(self, ctx: C) -> Result<T, Error>;
-}
-
-impl<T, E: std::error::Error + Send + Sync + 'static> ResultExt<T> for Result<T, E> {
-    fn wrap(self) -> Result<T, Error> {
-        self.map_err(|e| e.wrap())
-    }
-
-    fn context<C: Display + Send + Sync + 'static>(self, ctx: C) -> Result<T, Error> {
-        match self {
-            Ok(val) => Ok(val),
-            Err(err) => Err(err.context(ctx)),
-        }
-    }
+    #[error("One of the post middlewares (with info) couldn't process the response")]
+    HandlePostMiddlewareWithInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,5 @@
-use crate::prelude::*;
 use crate::types::RequestMeta;
+use crate::Error;
 use http::Extensions;
 use percent_encoding::percent_decode_str;
 
@@ -14,7 +14,7 @@ pub(crate) fn update_req_meta_in_extensions(ext: &mut Extensions, new_req_meta: 
 pub(crate) fn percent_decode_request_path(val: &str) -> crate::Result<String> {
     percent_decode_str(val)
         .decode_utf8()
-        .context("Couldn't decode the request path as UTF8")
+        .map_err(Error::DecodeRequestPath)
         .map(|val| val.to_string())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,7 +762,6 @@
 
 pub use self::error::Error;
 #[doc(hidden)]
-pub use self::error::{ErrorExt, ResultExt};
 pub use self::middleware::{Middleware, PostMiddleware, PreMiddleware};
 pub use self::route::Route;
 pub use self::router::{Router, RouterBuilder};

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -1,3 +1,1 @@
 pub use crate::ext::RequestExt;
-#[allow(unused_imports)]
-pub(crate) use crate::{ErrorExt, ResultExt};

--- a/src/regex_generator/mod.rs
+++ b/src/regex_generator/mod.rs
@@ -1,14 +1,14 @@
-use crate::prelude::*;
+use crate::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {
-    static ref PATH_PARAMS_RE: Regex = { Regex::new(r"(?s)(?::([^/]+))|(?:\*)").unwrap() };
+    static ref PATH_PARAMS_RE: Regex = Regex::new(r"(?s)(?::([^/]+))|(?:\*)").unwrap();
 }
 
-fn generate_common_regex_str(path: &str) -> crate::Result<(String, Vec<String>)> {
+fn generate_common_regex_str(path: &str) -> (String, Vec<String>) {
     let mut regex_str = String::with_capacity(path.len());
-    let mut param_names: Vec<String> = Vec::new();
+    let mut param_names = Vec::new();
 
     let mut pos: usize = 0;
 
@@ -32,21 +32,21 @@ fn generate_common_regex_str(path: &str) -> crate::Result<(String, Vec<String>)>
     let left_over_path_s = &path[pos..];
     regex_str += &regex::escape(left_over_path_s);
 
-    Ok((regex_str, param_names))
+    (regex_str, param_names)
 }
 
 pub(crate) fn generate_exact_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
-    let (common_regex_str, params) = generate_common_regex_str(path)?;
+    let (common_regex_str, params) = generate_common_regex_str(path);
     let re_str = format!("{}{}{}", r"(?s)^", common_regex_str, "$");
-    let re = Regex::new(re_str.as_str()).wrap()?;
+    let re = Regex::new(re_str.as_str()).map_err(|e| Error::GenerateExactMatchRegex(e, path.into()))?;
     Ok((re, params))
 }
 
 #[allow(dead_code)]
 pub(crate) fn generate_prefix_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
-    let (common_regex_str, params) = generate_common_regex_str(path)?;
+    let (common_regex_str, params) = generate_common_regex_str(path);
     let re_str = format!("{}{}", r"(?s)^", common_regex_str);
-    let re = Regex::new(re_str.as_str()).wrap()?;
+    let re = Regex::new(re_str.as_str()).map_err(|e| Error::GeneratePrefixMatchRegex(e, path.into()))?;
     Ok((re, params))
 }
 
@@ -57,29 +57,29 @@ mod tests {
     #[test]
     fn test_generate_common_regex_str_normal() {
         let path = "/";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/".to_owned(), Vec::<String>::new()));
 
         let path = "/api/v1/services/get_ip";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/api/v1/services/get_ip".to_owned(), Vec::<String>::new()))
     }
 
     #[test]
     fn test_generate_common_regex_str_special_character() {
         let path = "/users/user-data/view";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/user\-data/view".to_owned(), Vec::<String>::new()))
     }
 
     #[test]
     fn test_generate_common_regex_str_params() {
         let path = "/users/:username/data";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/([^/]+)/data".to_owned(), vec!["username".to_owned()]));
 
         let path = "/users/:username/data/:attr/view";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(
             r,
             (
@@ -89,30 +89,30 @@ mod tests {
         );
 
         let path = "/users/:username";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/([^/]+)".to_owned(), vec!["username".to_owned()]));
 
         let path = ":username";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"([^/]+)".to_owned(), vec!["username".to_owned()]));
     }
 
     #[test]
     fn test_generate_common_regex_str_star_globe() {
         let path = "*";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"(.*)".to_owned(), vec!["*".to_owned()]));
 
         let path = "/users/*";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/(.*)".to_owned(), vec!["*".to_owned()]));
 
         let path = "/users/*/data";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/(.*)/data".to_owned(), vec!["*".to_owned()]));
 
         let path = "/users/*/data/*";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(
             r,
             (
@@ -122,7 +122,7 @@ mod tests {
         );
 
         let path = "/users/**";
-        let r = generate_common_regex_str(path).unwrap();
+        let r = generate_common_regex_str(path);
         assert_eq!(r, (r"/users/(.*)(.*)".to_owned(), vec!["*".to_owned(), "*".to_owned()]));
     }
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,8 +1,8 @@
 use crate::data_map::ScopedDataMap;
 use crate::middleware::{PostMiddleware, PreMiddleware};
-use crate::prelude::*;
 use crate::route::Route;
 use crate::types::RequestInfo;
+use crate::Error;
 use hyper::{body::HttpBody, Request, Response};
 use regex::RegexSet;
 use std::fmt::{self, Debug, Formatter};
@@ -117,7 +117,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             .chain(self.post_middlewares.iter().map(|m| m.regex.as_str()))
             .chain(self.scoped_data_maps.iter().map(|d| d.regex.as_str()));
 
-        self.regex_set = Some(RegexSet::new(regex_iter).context("Couldn't create router RegexSet")?);
+        self.regex_set = Some(RegexSet::new(regex_iter).map_err(Error::CreateRouterRegexSet)?);
 
         Ok(())
     }
@@ -166,7 +166,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             .collect::<Vec<_>>();
 
         if let Some(ref mut req_info) = req_info {
-            if shared_data_maps.len() > 0 {
+            if !shared_data_maps.is_empty() {
                 req_info.shared_data_maps.replace(Box::new(shared_data_maps.clone()));
             }
         }
@@ -178,21 +178,15 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         for idx in matched_pre_middleware_idxs {
             let pre_middleware = &mut self.pre_middlewares[idx];
 
-            transformed_req = pre_middleware
-                .process(transformed_req)
-                .await
-                .context("One of the pre middlewares couldn't process the request")?;
+            transformed_req = pre_middleware.process(transformed_req).await?;
         }
 
-        let mut resp: Option<Response<B>> = None;
+        let mut resp = None;
         for idx in matched_route_idxs {
             let route = &mut self.routes[idx];
 
             if route.is_match_method(transformed_req.method()) {
-                let route_resp_res = route
-                    .process(target_path, transformed_req)
-                    .await
-                    .context("One of the routes couldn't process the request");
+                let route_resp_res = route.process(target_path, transformed_req).await;
 
                 let route_resp = match route_resp_res {
                     Ok(route_resp) => route_resp,
@@ -200,7 +194,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
                         if let Some(ref mut err_handler) = self.err_handler {
                             err_handler.execute(err, req_info.clone()).await
                         } else {
-                            return crate::Result::Err(err);
+                            return Err(err);
                         }
                     }
                 };
@@ -210,18 +204,14 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             }
         }
 
-        if let None = resp {
-            return Err(crate::Error::new("No handlers added to handle non-existent routes. Tips: Please add an '.any' route at the bottom to handle any routes."));
+        if resp.is_none() {
+            return Err(Error::HandleNonExistentRoute);
         }
 
         let mut transformed_res = resp.unwrap();
         for idx in matched_post_middleware_idxs {
             let post_middleware = &mut self.post_middlewares[idx];
-
-            transformed_res = post_middleware
-                .process(transformed_res, req_info.clone())
-                .await
-                .context("One of the post middlewares couldn't process the response")?;
+            transformed_res = post_middleware.process(transformed_res, req_info.clone()).await?;
         }
 
         Ok(transformed_res)

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -1,5 +1,4 @@
 use crate::helpers;
-use crate::prelude::*;
 use crate::router::Router;
 use crate::types::{RequestInfo, RequestMeta};
 use hyper::{body::HttpBody, service::Service, Request, Response};
@@ -40,8 +39,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
         let fut = async move {
             helpers::update_req_meta_in_extensions(req.extensions_mut(), RequestMeta::with_remote_addr(remote_addr));
 
-            let mut target_path = helpers::percent_decode_request_path(req.uri().path())
-                .context("Couldn't percent decode request path")?;
+            let mut target_path = helpers::percent_decode_request_path(req.uri().path())?;
 
             if target_path.as_bytes()[target_path.len() - 1] != b'/' {
                 target_path.push_str("/");


### PR DESCRIPTION
Copied over from #23.

This PR replaces the current error handling mechanism with `thiserror`.

The primary goal is to enable users to construct a full error cause chain from
`routerify::Error` regardless of what underlying libraries users' handlers are
calling into.

I believe this closes #15.