### PR TITLE
Remove unsafe and Unpin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ http = "0.2"
 regex = "1.3"
 lazy_static = "1.4"
 percent-encoding = "2.1"
+tokio = { version = "0.2", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -25,8 +25,10 @@ pub enum Middleware<B, E> {
     Post(PostMiddleware<B, E>),
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    Middleware<B, E>
+impl<B, E> Middleware<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     /// Creates a pre middleware with a handler at the `/*` path.
     ///
@@ -92,9 +94,9 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// async fn post_middleware_with_info_handler(res: Response<Body>, req_info: RequestInfo) -> Result<Response<Body>, Infallible> {
     ///     let headers = req_info.headers();
-    ///     
+    ///
     ///     // Do some response transformation based on the request headers, method etc.
-    ///     
+    ///
     ///     Ok(res)
     /// }
     ///
@@ -181,9 +183,9 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// async fn post_middleware_with_info_handler(res: Response<Body>, req_info: RequestInfo) -> Result<Response<Body>, Infallible> {
     ///     let _headers = req_info.headers();
-    ///     
+    ///
     ///     // Do some response transformation based on the request headers, method etc.
-    ///     
+    ///
     ///     Ok(res)
     /// }
     ///

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -35,8 +35,10 @@ pub(crate) enum Handler<B, E> {
     WithInfo(HandlerWithInfo<B, E>),
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    PostMiddleware<B, E>
+impl<B, E> PostMiddleware<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,
@@ -93,9 +95,9 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     ///
     /// async fn post_middleware_with_info_handler(res: Response<Body>, req_info: RequestInfo) -> Result<Response<Body>, Infallible> {
     ///     let headers = req_info.headers();
-    ///     
+    ///
     ///     // Do some response transformation based on the request headers, method etc.
-    ///     
+    ///
     ///     Ok(res)
     /// }
     ///

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -22,11 +22,14 @@ pub struct PreMiddleware<E> {
     pub(crate) handler: Option<Handler<E>>,
 }
 
-impl<E: std::error::Error + Send + Sync + Unpin + 'static> PreMiddleware<E> {
-    pub(crate) fn new_with_boxed_handler<P: Into<String>>(
-        path: P,
-        handler: Handler<E>,
-    ) -> crate::Result<PreMiddleware<E>> {
+impl<E> PreMiddleware<E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    pub(crate) fn new_with_boxed_handler<P>(path: P, handler: Handler<E>) -> crate::Result<PreMiddleware<E>>
+    where
+        P: Into<String>,
+    {
         let path = path.into();
         let (re, _) = generate_exact_match_regex(path.as_str())
             .context("Could not create an exact match regex for the pre middleware path")?;

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -53,17 +53,24 @@ pub struct Route<B, E> {
     pub(crate) methods: Vec<Method>,
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Route<B, E> {
-    pub(crate) fn new_with_boxed_handler<P: Into<String>>(
+impl<B, E> Route<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    pub(crate) fn new_with_boxed_handler<P>(
         path: P,
         methods: Vec<Method>,
         handler: Handler<B, E>,
-    ) -> crate::Result<Route<B, E>> {
+    ) -> crate::Result<Route<B, E>>
+    where
+        P: Into<String>,
+    {
         let path = path.into();
         let (re, params) = generate_exact_match_regex(path.as_str())
             .context("Could not create an exact match regex for the route path")?;
 
-        Ok(Route {
+        Ok(Self {
             path,
             regex: re,
             route_params: params,

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -62,8 +62,10 @@ struct BuilderInner<B, E> {
     err_handler: Option<ErrHandler<B>>,
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterBuilder<B, E>
+impl<B, E> RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     /// Creates a new `RouterBuilder` instance with default options.
     pub fn new() -> RouterBuilder<B, E> {
@@ -105,8 +107,10 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterBuilder<B, E>
+impl<B, E> RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     /// Adds a new route with `GET` method and the handler at the specified path.
     ///
@@ -633,8 +637,10 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterBuilder<B, E>
+impl<B, E> RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     /// Adds a single middleware. A pre middleware can be created by [`Middleware::pre`](./enum.Middleware.html#method.pre) method and a post
     /// middleware can be created by [`Middleware::post`](./enum.Middleware.html#method.post) method.
@@ -729,11 +735,13 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Default
-    for RouterBuilder<B, E>
+impl<B, E> Default for RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
-    fn default() -> RouterBuilder<B, E> {
-        RouterBuilder {
+    fn default() -> Self {
+        Self {
             inner: Ok(BuilderInner {
                 pre_middlewares: Vec::new(),
                 routes: Vec::new(),

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -78,7 +78,10 @@ pub(crate) enum ErrHandler<B> {
     WithInfo(ErrHandlerWithInfo<B>),
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static> ErrHandler<B> {
+impl<B> ErrHandler<B>
+where
+    B: HttpBody + Send + Sync + 'static,
+{
     pub(crate) async fn execute(&mut self, err: crate::Error, req_info: Option<RequestInfo>) -> Response<B> {
         match self {
             ErrHandler::WithoutInfo(ref mut err_handler) => Pin::from(err_handler(err)).await,
@@ -89,7 +92,11 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static> ErrHandler<B> {
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Router<B, E> {
+impl<B, E> Router<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
     pub(crate) fn new(
         pre_middlewares: Vec<PreMiddleware<E>>,
         routes: Vec<Route<B, E>>,
@@ -166,8 +173,8 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
             .collect::<Vec<_>>();
 
         if let Some(ref mut req_info) = req_info {
-            if shared_data_maps.len() > 0 {
-                req_info.shared_data_maps.replace(Box::new(shared_data_maps.clone()));
+            if !shared_data_maps.is_empty() {
+                req_info.shared_data_maps.replace(shared_data_maps.clone());
             }
         }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,7 @@
 pub use request_service::RequestService;
 pub use router_service::RouterService;
 
+pub(crate) type BoxedFutureResult<R, E> = Box<dyn std::future::Future<Output = Result<R, E>> + Send + 'static>;
+
 mod request_service;
 mod router_service;

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -1,73 +1,65 @@
 use crate::helpers;
 use crate::prelude::*;
 use crate::router::Router;
+use crate::service::BoxedFutureResult;
 use crate::types::{RequestInfo, RequestMeta};
 use hyper::{body::HttpBody, service::Service, Request, Response};
-use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
+use tokio::sync::Mutex;
 
 pub struct RequestService<B, E> {
-    pub(crate) router: *mut Router<B, E>,
+    pub(crate) router: Arc<Mutex<Router<B, E>>>,
     pub(crate) remote_addr: SocketAddr,
 }
 
-unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Send
-    for RequestService<B, E>
-{
-}
-unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Sync
-    for RequestService<B, E>
-{
-}
-
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    Service<Request<hyper::Body>> for RequestService<B, E>
+impl<B, E> Service<Request<hyper::Body>> for RequestService<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     type Response = Response<B>;
     type Error = crate::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+    type Future = Pin<BoxedFutureResult<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, mut req: Request<hyper::Body>) -> Self::Future {
-        let router = unsafe { &mut *self.router };
-        let remote_addr = self.remote_addr;
+        helpers::update_req_meta_in_extensions(req.extensions_mut(), RequestMeta::with_remote_addr(self.remote_addr));
 
-        let fut = async move {
-            helpers::update_req_meta_in_extensions(req.extensions_mut(), RequestMeta::with_remote_addr(remote_addr));
-
+        let router = self.router.clone();
+        Box::pin(async move {
             let mut target_path = helpers::percent_decode_request_path(req.uri().path())
                 .context("Couldn't percent decode request path")?;
 
             if target_path.as_bytes()[target_path.len() - 1] != b'/' {
-                target_path.push_str("/");
+                target_path.push('/');
             }
 
-            let mut req_info = None;
+            let mut router = router.lock().await;
             let should_gen_req_info = router
                 .should_gen_req_info
                 .expect("The `should_gen_req_info` flag in Router is not initialized");
-
-            if should_gen_req_info {
-                req_info = Some(RequestInfo::new_from_req(&req));
-            }
+            let req_info = if should_gen_req_info {
+                Some(RequestInfo::new_from_req(&req))
+            } else {
+                None
+            };
 
             match router.process(target_path.as_str(), req, req_info.clone()).await {
-                Ok(resp) => crate::Result::Ok(resp),
+                Ok(resp) => Ok(resp),
                 Err(err) => {
                     if let Some(ref mut err_handler) = router.err_handler {
-                        crate::Result::Ok(err_handler.execute(err, req_info.clone()).await)
+                        Ok(err_handler.execute(err, req_info).await)
                     } else {
-                        crate::Result::Err(err)
+                        Err(err)
                     }
                 }
             }
-        };
-
-        Box::pin(fut)
+        })
     }
 }

--- a/src/types/request_info.rs
+++ b/src/types/request_info.rs
@@ -1,5 +1,5 @@
 use crate::data_map::SharedDataMap;
-use hyper::{Body, HeaderMap, Method, Request, Uri, Version};
+use hyper::{HeaderMap, Method, Request, Uri, Version};
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct RequestInfo {
     pub(crate) req_info_inner: Arc<RequestInfoInner>,
-    pub(crate) shared_data_maps: Option<Box<Vec<SharedDataMap>>>,
+    pub(crate) shared_data_maps: Option<Vec<SharedDataMap>>,
 }
 
 #[derive(Debug)]
@@ -22,16 +22,14 @@ pub(crate) struct RequestInfoInner {
 }
 
 impl RequestInfo {
-    pub(crate) fn new_from_req(req: &Request<Body>) -> Self {
-        let inner = RequestInfoInner {
-            headers: req.headers().clone(),
-            method: req.method().clone(),
-            uri: req.uri().clone(),
-            version: req.version(),
-        };
-
-        RequestInfo {
-            req_info_inner: Arc::new(inner),
+    pub(crate) fn new_from_req<B>(req: &Request<B>) -> Self {
+        Self {
+            req_info_inner: Arc::new(RequestInfoInner {
+                headers: req.headers().clone(),
+                method: req.method().clone(),
+                uri: req.uri().clone(),
+                version: req.version(),
+            }),
             shared_data_maps: None,
         }
     }
@@ -69,7 +67,7 @@ impl RequestInfo {
             }
         }
 
-        return None;
+        None
     }
 }
 

--- a/src/types/route_params.rs
+++ b/src/types/route_params.rs
@@ -39,7 +39,7 @@ impl RouteParams {
     /// let router = Router::builder()
     ///     .get("/users/:userName/books/:bookName", |req| async move {
     ///         let params: &RouteParams = req.params();
-    ///         
+    ///
     ///         let user_name = params.get("userName").unwrap();
     ///         let book_name = params.get("bookName").unwrap();
     ///
@@ -69,7 +69,7 @@ impl RouteParams {
     /// let router = Router::builder()
     ///     .get("/users/:userName", |req| async move {
     ///         let params: &RouteParams = req.params();
-    ///         
+    ///
     ///         if params.has("userName") {
     ///             Ok(Response::new(Body::from(params.get("userName").unwrap().to_string())))
     ///         } else {


### PR DESCRIPTION
This PR replaces the unsafe code with its safe equivalent.

Mutating operations on `*mut Router<B, E>` assume a single unique mutable reference, which presumably was guaranteed in some way before this PR. This PR replaces the unsafe implementation with a shared mutable reference whose semantics are enforced by the compiler.

Additionally the `Unpin` constraints that were bounding many of the generics in this library are no longer necessary.