### PR TITLE
convert empty paths to / instead of panicking

### DIFF
--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -41,7 +41,7 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
 
             let mut target_path = helpers::percent_decode_request_path(req.uri().path())?;
 
-            if target_path.as_bytes()[target_path.len() - 1] != b'/' {
+            if target_path.is_empty() || target_path.as_bytes()[target_path.len() - 1] != b'/' {
                 target_path.push_str("/");
             }
 


### PR DESCRIPTION
if the path was not proper url library couldnt parse it and the path was empty which panics when tried to index it now it checks for the empty path first fixing #36 