### PR TITLE
Implement RequestServiceBuilder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run tests
-        run: cargo test --verbose --features="all"
+        run: cargo test --verbose --features="all" --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,10 @@ thiserror = "1"
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3" }
+
+# For the AWS Lambda example
+aws_lambda_events = "0.4.0"
+lambda_http = { package = "netlify_lambda_http", version = "0.2.0" }
+slog = "2"
+sloggers = "1.0"
+url = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+futures = { version = "0.3" }

--- a/examples/aws_lambda.rs
+++ b/examples/aws_lambda.rs
@@ -1,0 +1,176 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::{net::SocketAddr, str::FromStr};
+
+use aws_lambda_events::{
+    encodings::Body,
+    event::apigw::{
+        ApiGatewayProxyRequestContext, ApiGatewayV2httpRequestContext, ApiGatewayV2httpRequestContextHttpDescription,
+    },
+};
+use futures::future::poll_fn;
+use hyper::service::Service;
+use lambda_http::{
+    handler,
+    lambda::{self, Context},
+    request::RequestContext,
+    IntoResponse, Request, RequestExt, Response,
+};
+use slog::debug;
+use sloggers::terminal::{Destination, TerminalLoggerBuilder};
+use sloggers::types::Severity;
+use sloggers::Build;
+
+use routerify::{RequestServiceBuilder, Router};
+
+type HandlerError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+const SERVER_ADDR: &str = "127.0.0.1:8080";
+
+#[tokio::main]
+async fn main() -> Result<(), HandlerError> {
+    std::env::set_var("RUST_BACKTRACE", "1");
+    lambda::run(handler(entrypoint)).await?;
+    Ok(())
+}
+
+async fn entrypoint(req: Request, _ctx: Context) -> Result<impl IntoResponse, HandlerError> {
+    let level = Severity::Info;
+    // let level = Severity::Trace;
+    let logger = TerminalLoggerBuilder::new()
+        .level(level)
+        .destination(Destination::Stderr)
+        .build()
+        .unwrap();
+
+    // Cache the query parameters.
+    let query_params = req.query_string_parameters();
+
+    // Convert the lambda_http::Request into a hyper::Request, replacing the URI
+    // with the local address of the routerify server.
+    let remote_addr = get_remote_addr(&req);
+    let (mut parts, body) = req.into_parts();
+    let body = match body {
+        Body::Empty => hyper::Body::empty(),
+        Body::Text(t) => hyper::Body::from(t.into_bytes()),
+        Body::Binary(b) => hyper::Body::from(b),
+    };
+    let mut uri = format!("http://{}{}", SERVER_ADDR, parts.uri.path());
+
+    // AWS Lambda Rust Runtime will automatically parse the query params *and*
+    // remove those query parameters from the original URI. This is fine if
+    // you're writing your logic directly in the handler function, but for
+    // passing-through to a separate router library, we need to
+    // re-url-encode the query parameters and place them back into the URI.
+    if !query_params.is_empty() {
+        append_querystring_from_map(&mut uri, query_params.iter());
+    }
+
+    parts.uri = match hyper::Uri::from_str(uri.as_str()) {
+        Ok(uri) => uri,
+        Err(e) => panic!("failed to build uri: {:?}", e),
+    };
+    let req = hyper::Request::from_parts(parts, body);
+    debug!(logger, "lambda request: {:#?}", req);
+    debug!(logger, "request uri path: {}", req.uri().path());
+
+    let router: Router<hyper::body::Body, routerify::Error> = Router::builder()
+        .get("/", |_| async move { Ok(Response::new("Hello, world!".into())) })
+        .build()
+        .unwrap();
+
+    let mut builder = RequestServiceBuilder::new(router)?;
+    let mut service = builder.build(remote_addr);
+    if let Err(e) = poll_fn(|ctx| service.poll_ready(ctx)).await {
+        panic!("request service is not ready: {:?}", e);
+    }
+    let resp: Response<hyper::body::Body> = service.call(req).await?;
+
+    // Parse the hyper::Request from Routerify into a lambda_http::Request
+    let (parts, body) = resp.into_parts();
+    let body_bytes = hyper::body::to_bytes(body).await?;
+    let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+    Ok(Response::from_parts(parts, Body::from(body)))
+}
+
+fn get_remote_addr(req: &Request) -> SocketAddr {
+    const PORT: u16 = 8080;
+    let source_ip: String = match req.request_context() {
+        RequestContext::ApiGatewayV1(ApiGatewayProxyRequestContext { identity, .. }) => {
+            identity.source_ip.unwrap_or_else(|| Ipv4Addr::UNSPECIFIED.to_string())
+        }
+        RequestContext::ApiGatewayV2(ApiGatewayV2httpRequestContext {
+            http: ApiGatewayV2httpRequestContextHttpDescription { source_ip, .. },
+            ..
+        }) => source_ip.unwrap_or_else(|| Ipv4Addr::UNSPECIFIED.to_string()),
+        _ => Ipv4Addr::UNSPECIFIED.to_string(),
+    };
+    SocketAddr::new(IpAddr::from_str(source_ip.as_str()).unwrap(), PORT)
+}
+
+fn append_querystring_from_map<'a, I>(uri: &mut String, from_query_params: I)
+where
+    I: Iterator<Item = (&'a str, &'a str)>,
+{
+    uri.push('?');
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (key, value) in from_query_params.into_iter() {
+        serializer.append_pair(key, value);
+    }
+    uri.push_str(serializer.finish().as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use hyper::{Method, StatusCode};
+
+    use super::*;
+
+    #[test]
+    fn should_parse_query_params_as_expected() {
+        // let expected = "?FOO=BAR&BOO=BAZ&key=value";
+        let mut buffer = String::new();
+        let query_params = {
+            let mut m = HashMap::new();
+            m.insert("FOO", "BAR");
+            m.insert("BOO", "BAZ");
+            m.insert("key", "value");
+            m
+        };
+        append_querystring_from_map(&mut buffer, query_params.clone().into_iter());
+        for (key, value) in query_params {
+            assert!(buffer.contains(&(key.to_string() + "=" + value)));
+        }
+    }
+
+    #[tokio::test]
+    async fn should_return_200_and_response() {
+        let mut request = lambda_http::Request::new(aws_lambda_events::encodings::Body::Empty);
+        *request.uri_mut() = "/".parse().unwrap();
+        request
+            .extensions_mut()
+            .insert::<RequestContext>(RequestContext::ApiGatewayV2(ApiGatewayV2httpRequestContext {
+                route_key: None,
+                account_id: None,
+                stage: None,
+                request_id: None,
+                authorizer: None,
+                apiid: None,
+                domain_name: None,
+                domain_prefix: None,
+                time: None,
+                time_epoch: 0,
+                http: ApiGatewayV2httpRequestContextHttpDescription {
+                    method: Method::GET,
+                    path: None,
+                    protocol: None,
+                    source_ip: Some("127.0.0.1".to_string()),
+                    user_agent: None,
+                },
+            }));
+        let response = entrypoint(request, Context::default()).await.unwrap().into_response();
+        assert_eq!(StatusCode::OK, response.status());
+        assert!(!response.body().is_empty())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,6 +766,7 @@ pub use self::route::Route;
 pub use self::router::{Router, RouterBuilder};
 #[doc(hidden)]
 pub use self::service::RequestService;
+pub use self::service::RequestServiceBuilder;
 pub use self::service::RouterService;
 pub use self::types::{RequestInfo, RouteParams};
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,10 +1,16 @@
+use crate::constants;
 use crate::data_map::ScopedDataMap;
 use crate::middleware::{PostMiddleware, PreMiddleware};
 use crate::route::Route;
 use crate::types::RequestInfo;
 use crate::Error;
-use hyper::{body::HttpBody, Request, Response};
+use hyper::{
+    body::HttpBody,
+    header::{self, HeaderValue},
+    Method, Request, Response, StatusCode,
+};
 use regex::RegexSet;
+use std::any::Any;
 use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
@@ -136,6 +142,123 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
         }
 
         self.should_gen_req_info = Some(false);
+    }
+
+    pub(crate) fn init_x_powered_by_middleware(&mut self) {
+        let x_powered_by_post_middleware = PostMiddleware::new("/*", |mut res| async move {
+            res.headers_mut().insert(
+                constants::HEADER_NAME_X_POWERED_BY,
+                HeaderValue::from_static(constants::HEADER_VALUE_X_POWERED_BY),
+            );
+            Ok(res)
+        })
+        .unwrap();
+
+        self.post_middlewares.insert(0, x_powered_by_post_middleware);
+    }
+
+    // pub(crate) fn init_keep_alive_middleware(&mut self) {
+    //     let keep_alive_post_middleware = PostMiddleware::new("/*", |mut res| async move {
+    //         res.headers_mut()
+    //             .insert(header::CONNECTION, HeaderValue::from_static("keep-alive"));
+    //         Ok(res)
+    //     })
+    //     .unwrap();
+
+    //     self.post_middlewares.push(keep_alive_post_middleware);
+    // }
+
+    pub(crate) fn init_global_options_route(&mut self) {
+        let options_method = vec![Method::OPTIONS];
+        let found = self
+            .routes
+            .iter()
+            .any(|route| route.path == "/*" && route.methods.as_slice() == options_method.as_slice());
+
+        if found {
+            return;
+        }
+
+        if let Some(router) = self.downcast_to_hyper_body_type() {
+            let options_route: Route<hyper::Body, E> = Route::new("/*", options_method, |_req| async move {
+                Ok(Response::builder()
+                    .status(StatusCode::NO_CONTENT)
+                    .body(hyper::Body::empty())
+                    .expect("Couldn't create the default OPTIONS response"))
+            })
+            .unwrap();
+
+            router.routes.push(options_route);
+        } else {
+            eprintln!(
+                "Warning: No global `options method` route added. It is recommended to send response to any `options` request.\n\
+                Please add one by calling `.options(\"/*\", handler)` method of the root router builder.\n"
+            );
+        }
+    }
+
+    pub(crate) fn init_default_404_route(&mut self) {
+        let found = self
+            .routes
+            .iter()
+            .any(|route| route.path == "/*" && route.methods.as_slice() == &constants::ALL_POSSIBLE_HTTP_METHODS[..]);
+
+        if found {
+            return;
+        }
+
+        if let Some(router) = self.downcast_to_hyper_body_type() {
+            let default_404_route: Route<hyper::Body, E> =
+                Route::new("/*", constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), |_req| async move {
+                    Ok(Response::builder()
+                        .status(StatusCode::NOT_FOUND)
+                        .header(header::CONTENT_TYPE, "text/plain")
+                        .body(hyper::Body::from(StatusCode::NOT_FOUND.canonical_reason().unwrap()))
+                        .expect("Couldn't create the default 404 response"))
+                })
+                .unwrap();
+            router.routes.push(default_404_route);
+        } else {
+            eprintln!(
+                "Warning: No default 404 route added. It is recommended to send 404 response to any non-existent route.\n\
+                Please add one by calling `.any(handler)` method of the root router builder.\n"
+            );
+        }
+    }
+
+    pub(crate) fn init_err_handler(&mut self) {
+        let found = self.err_handler.is_some();
+
+        if found {
+            return;
+        }
+
+        if let Some(router) = self.downcast_to_hyper_body_type() {
+            let handler: ErrHandler<hyper::Body> = ErrHandler::WithoutInfo(Box::new(move |err: crate::Error| {
+                Box::new(async move {
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .header(header::CONTENT_TYPE, "text/plain")
+                        .body(hyper::Body::from(format!(
+                            "{}: {}",
+                            StatusCode::INTERNAL_SERVER_ERROR.canonical_reason().unwrap(),
+                            err
+                        )))
+                        .expect("Couldn't create a response while handling the server error")
+                })
+            }));
+            router.err_handler = Some(handler);
+        } else {
+            eprintln!(
+                "Warning: No error handler added. It is recommended to add one to see what went wrong if any route or middleware fails.\n\
+                Please add one by calling `.err_handler(handler)` method of the root router builder.\n"
+            );
+        }
+    }
+
+    fn downcast_to_hyper_body_type(&mut self) -> Option<&mut Router<hyper::Body, E>> {
+        let any_obj: &mut dyn Any = self;
+        any_obj.downcast_mut::<Router<hyper::Body, E>>()
     }
 
     /// Return a [RouterBuilder](./struct.RouterBuilder.html) instance to build a `Router`.

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,4 @@
-pub use request_service::RequestService;
+pub use request_service::{RequestService, RequestServiceBuilder};
 pub use router_service::RouterService;
 
 mod request_service;

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -103,8 +103,8 @@ impl<B, E> RequestServiceBuilder<B, E> {
 #[cfg(test)]
 mod tests {
     use crate::{Error, RequestServiceBuilder, Router};
+    use futures::future::poll_fn;
     use http::Method;
-    use hyper::server::accept::poll_fn;
     use hyper::service::Service;
     use hyper::{Body, Request, Response};
     use std::net::SocketAddr;
@@ -126,7 +126,7 @@ mod tests {
             .unwrap();
         let mut builder = RequestServiceBuilder::new(router).unwrap();
         let mut service = builder.build(remote_addr);
-        poll_fn(|_| -> Poll<Option<Result<(), Error>>> { Poll::Ready(Some(Ok(()))) });
+        poll_fn(|_| -> Poll<Result<(), Error>> { Poll::Ready(Ok(())) });
         let resp: Response<hyper::body::Body> = service.call(req).await.unwrap();
         let body = resp.into_body();
         let body = String::from_utf8(hyper::body::to_bytes(body).await.unwrap().to_vec()).unwrap();

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -126,9 +126,7 @@ mod tests {
             .unwrap();
         let mut builder = RequestServiceBuilder::new(router).unwrap();
         let mut service = builder.build(remote_addr);
-        if let Err(e) = poll_fn(|ctx| -> Poll<Result<(), Error>> { service.poll_ready(ctx) }).await {
-            panic!("request service is not ready: {}", e);
-        }
+        poll_fn(|ctx| -> Poll<Result<(), Error>> { service.poll_ready(ctx) }).await.expect("request service is not ready");
         let resp: Response<hyper::body::Body> = service.call(req).await.unwrap();
         let body = resp.into_body();
         let body = String::from_utf8(hyper::body::to_bytes(body).await.unwrap().to_vec()).unwrap();

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -126,7 +126,9 @@ mod tests {
             .unwrap();
         let mut builder = RequestServiceBuilder::new(router).unwrap();
         let mut service = builder.build(remote_addr);
-        poll_fn(|_| -> Poll<Result<(), Error>> { Poll::Ready(Ok(())) });
+        if let Err(e) = poll_fn(|ctx| -> Poll<Result<(), Error>> { service.poll_ready(ctx) }).await {
+            panic!("request service is not ready: {}", e);
+        }
         let resp: Response<hyper::body::Body> = service.call(req).await.unwrap();
         let body = resp.into_body();
         let body = String::from_utf8(hyper::body::to_bytes(body).await.unwrap().to_vec()).unwrap();

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -104,10 +104,12 @@ impl<B, E> RequestServiceBuilder<B, E> {
 mod tests {
     use crate::{Error, RequestServiceBuilder, Router};
     use http::Method;
+    use hyper::server::accept::poll_fn;
     use hyper::service::Service;
     use hyper::{Body, Request, Response};
     use std::net::SocketAddr;
     use std::str::FromStr;
+    use std::task::Poll;
 
     #[tokio::test]
     async fn should_route_request() {
@@ -124,7 +126,7 @@ mod tests {
             .unwrap();
         let mut builder = RequestServiceBuilder::new(router).unwrap();
         let mut service = builder.build(remote_addr);
-        // poll_fn(|_| -> Poll<Option<Result<(), Error>>> { Poll::Ready(Some(Ok(()))) });
+        poll_fn(|_| -> Poll<Option<Result<(), Error>>> { Poll::Ready(Some(Ok(()))) });
         let resp: Response<hyper::body::Body> = service.call(req).await.unwrap();
         let body = resp.into_body();
         let body = String::from_utf8(hyper::body::to_bytes(body).await.unwrap().to_vec()).unwrap();

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -89,9 +89,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
             router: Arc::from(router),
         })
     }
-}
 
-impl<B, E> RequestServiceBuilder<B, E> {
     pub fn build(&mut self, remote_addr: SocketAddr) -> RequestService<B, E> {
         RequestService {
             router: self.router.clone(),
@@ -126,7 +124,9 @@ mod tests {
             .unwrap();
         let mut builder = RequestServiceBuilder::new(router).unwrap();
         let mut service = builder.build(remote_addr);
-        poll_fn(|ctx| -> Poll<Result<(), Error>> { service.poll_ready(ctx) }).await.expect("request service is not ready");
+        poll_fn(|ctx| -> Poll<Result<(), Error>> { service.poll_ready(ctx) })
+            .await
+            .expect("request service is not ready");
         let resp: Response<hyper::body::Body> = service.call(req).await.unwrap();
         let body = resp.into_body();
         let body = String::from_utf8(hyper::body::to_bytes(body).await.unwrap().to_vec()).unwrap();

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -1,21 +1,9 @@
-use crate::constants;
-use crate::middleware::PostMiddleware;
-use crate::route::Route;
-use crate::router::ErrHandler;
 use crate::router::Router;
-use crate::service::request_service::RequestService;
-use hyper::{
-    body::HttpBody,
-    header::{self, HeaderValue},
-    server::conn::AddrStream,
-    service::Service,
-    Method, Response, StatusCode,
-};
-use std::any::Any;
+use crate::service::request_service::{RequestService, RequestServiceBuilder};
+use hyper::{body::HttpBody, server::conn::AddrStream, service::Service};
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 /// A [`Service`](https://docs.rs/hyper/0.13.5/hyper/service/trait.Service.html) to process incoming requests.
@@ -67,7 +55,7 @@ use std::task::{Context, Poll};
 /// ```
 #[derive(Debug)]
 pub struct RouterService<B, E> {
-    router: Arc<Router<B, E>>,
+    builder: RequestServiceBuilder<B, E>,
 }
 
 impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
@@ -75,138 +63,9 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
 {
     /// Creates a new service with the provided router and it's ready to be used with the hyper [`serve`](https://docs.rs/hyper/0.13.5/hyper/server/struct.Builder.html#method.serve)
     /// method.
-    pub fn new(mut router: Router<B, E>) -> crate::Result<RouterService<B, E>> {
-        Self::init_router_with_x_powered_by_middleware(&mut router);
-        // Self::init_router_with_keep_alive_middleware(&mut router);
-
-        Self::init_router_with_global_options_route(&mut router);
-        Self::init_router_with_default_404_route(&mut router);
-
-        Self::init_router_with_err_handler(&mut router);
-
-        router.init_regex_set()?;
-        router.init_req_info_gen();
-
-        Ok(RouterService {
-            router: Arc::new(router),
-        })
-    }
-
-    fn init_router_with_x_powered_by_middleware(router: &mut Router<B, E>) {
-        let x_powered_by_post_middleware = PostMiddleware::new("/*", |mut res| async move {
-            res.headers_mut().insert(
-                constants::HEADER_NAME_X_POWERED_BY,
-                HeaderValue::from_static(constants::HEADER_VALUE_X_POWERED_BY),
-            );
-            Ok(res)
-        })
-        .unwrap();
-
-        router.post_middlewares.insert(0, x_powered_by_post_middleware);
-    }
-
-    // fn init_router_with_keep_alive_middleware(router: &mut Router<B, E>) {
-    //     let keep_alive_post_middleware = PostMiddleware::new("/*", |mut res| async move {
-    //         res.headers_mut()
-    //             .insert(header::CONNECTION, HeaderValue::from_static("keep-alive"));
-    //         Ok(res)
-    //     })
-    //     .unwrap();
-
-    //     router.post_middlewares.push(keep_alive_post_middleware);
-    // }
-
-    fn init_router_with_global_options_route(router: &mut Router<B, E>) {
-        let options_method = vec![Method::OPTIONS];
-        let found = router
-            .routes
-            .iter()
-            .any(|route| route.path == "/*" && route.methods.as_slice() == options_method.as_slice());
-
-        if found {
-            return;
-        }
-
-        if let Some(router) = Self::downcast_router_to_hyper_body_type(router) {
-            let options_route: Route<hyper::Body, E> = Route::new("/*", options_method, |_req| async move {
-                Ok(Response::builder()
-                    .status(StatusCode::NO_CONTENT)
-                    .body(hyper::Body::empty())
-                    .expect("Couldn't create the default OPTIONS response"))
-            })
-            .unwrap();
-
-            router.routes.push(options_route);
-        } else {
-            eprintln!(
-                "Warning: No global `options method` route added. It is recommended to send response to any `options` request.\n\
-                Please add one by calling `.options(\"/*\", handler)` method of the root router builder.\n"
-            );
-        }
-    }
-
-    fn init_router_with_default_404_route(router: &mut Router<B, E>) {
-        let found = router
-            .routes
-            .iter()
-            .any(|route| route.path == "/*" && route.methods.as_slice() == &constants::ALL_POSSIBLE_HTTP_METHODS[..]);
-
-        if found {
-            return;
-        }
-
-        if let Some(router) = Self::downcast_router_to_hyper_body_type(router) {
-            let default_404_route: Route<hyper::Body, E> =
-                Route::new("/*", constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), |_req| async move {
-                    Ok(Response::builder()
-                        .status(StatusCode::NOT_FOUND)
-                        .header(header::CONTENT_TYPE, "text/plain")
-                        .body(hyper::Body::from(StatusCode::NOT_FOUND.canonical_reason().unwrap()))
-                        .expect("Couldn't create the default 404 response"))
-                })
-                .unwrap();
-            router.routes.push(default_404_route);
-        } else {
-            eprintln!(
-                "Warning: No default 404 route added. It is recommended to send 404 response to any non-existent route.\n\
-                Please add one by calling `.any(handler)` method of the root router builder.\n"
-            );
-        }
-    }
-
-    fn init_router_with_err_handler(router: &mut Router<B, E>) {
-        let found = router.err_handler.is_some();
-
-        if found {
-            return;
-        }
-
-        if let Some(router) = Self::downcast_router_to_hyper_body_type(router) {
-            let handler: ErrHandler<hyper::Body> = ErrHandler::WithoutInfo(Box::new(move |err: crate::Error| {
-                Box::new(async move {
-                    Response::builder()
-                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .header(header::CONTENT_TYPE, "text/plain")
-                        .body(hyper::Body::from(format!(
-                            "{}: {}",
-                            StatusCode::INTERNAL_SERVER_ERROR.canonical_reason().unwrap(),
-                            err
-                        )))
-                        .expect("Couldn't create a response while handling the server error")
-                })
-            }));
-            router.err_handler = Some(handler);
-        } else {
-            eprintln!(
-                "Warning: No error handler added. It is recommended to add one to see what went wrong if any route or middleware fails.\n\
-                Please add one by calling `.err_handler(handler)` method of the root router builder.\n"
-            );
-        }
-    }
-
-    fn downcast_router_to_hyper_body_type(router: &mut Router<B, E>) -> Option<&mut Router<hyper::Body, E>> {
-        let any_obj: &mut dyn Any = router;
-        any_obj.downcast_mut::<Router<hyper::Body, E>>()
+    pub fn new(router: Router<B, E>) -> crate::Result<RouterService<B, E>> {
+        let builder = RequestServiceBuilder::new(router)?;
+        Ok(RouterService { builder })
     }
 }
 
@@ -222,12 +81,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     }
 
     fn call(&mut self, conn: &AddrStream) -> Self::Future {
-        let remote_addr = conn.remote_addr();
-
-        let req_service = RequestService {
-            router: self.router.clone(),
-            remote_addr,
-        };
+        let req_service = self.builder.build(conn.remote_addr());
 
         let fut = async move { Ok(req_service) };
 


### PR DESCRIPTION
This is based on work by @aetf [in this commit](https://github.com/Aetf/routerify/commit/6627e965dea0c2bc07d50975c445b687dff3b1a9), which I found while reviewing the public forks of Routerify. 

> "Completely decouple the route processing from
> request handling, enabling using the library in
> AWS lambda rust runtime."

Running within AWS Lambda is my [usecase](https://github.com/seanpianka/rust-routerify-aws-lambda-quickstart)/focus of study. The original author suggested avoiding the steps of starting a Hyper server and client on every request (discussion is on the original commit webpage). I found this change useful, so we should consider adding this separation for other users who may require this as a part of their workflow.

The change has been written using the updated Tokio 1.0/Hyper 0.14 fork referenced in #35 and so is blocked waiting for its merge. 