### PR TITLE
Make the router error type more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Contributors](https://img.shields.io/github/contributors/routerify/routerify.svg)](https://github.com/orgs/routerify/people)
 [![MIT](https://img.shields.io/crates/l/routerify.svg)](./LICENSE)
 
-# Looking for a maintainer. Please ping me at hello@rousan.io, if anyone is interested to actively maintain this repo.
+# Looking for a maintainer. Please ping me at hello@rousan.io, if anyone is interested to actively maintain this project.
 
 # Routerify
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Contributors](https://img.shields.io/github/contributors/routerify/routerify.svg)](https://github.com/orgs/routerify/people)
 [![MIT](https://img.shields.io/crates/l/routerify.svg)](./LICENSE)
 
+# Looking for a maintainer. Please ping me at hello@rousan.io, if anyone is interested to actively maintain this repo.
+
 # Routerify
 
 The `Routerify` provides a lightweight, idiomatic, composable and modular router implementation with middleware support for the Rust HTTP library [hyper.rs](https://hyper.rs/).

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 [![Contributors](https://img.shields.io/github/contributors/routerify/routerify.svg)](https://github.com/orgs/routerify/people)
 [![MIT](https://img.shields.io/crates/l/routerify.svg)](./LICENSE)
 
-# Looking for a maintainer. Please ping me at hello@rousan.io, if anyone is interested to actively maintain this project.
-
 # Routerify
 
 The `Routerify` provides a lightweight, idiomatic, composable and modular router implementation with middleware support for the Rust HTTP library [hyper.rs](https://hyper.rs/).

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -25,8 +25,10 @@ pub enum Middleware<B, E> {
     Post(PostMiddleware<B, E>),
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    Middleware<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Middleware<B, E>
 {
     /// Creates a pre middleware with a handler at the `/*` path.
     ///

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -35,8 +35,10 @@ pub(crate) enum Handler<B, E> {
     WithInfo(HandlerWithInfo<B, E>),
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    PostMiddleware<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > PostMiddleware<B, E>
 {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -22,7 +22,7 @@ pub struct PreMiddleware<E> {
     pub(crate) handler: Option<Handler<E>>,
 }
 
-impl<E: std::error::Error + Send + Sync + Unpin + 'static> PreMiddleware<E> {
+impl<E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static> PreMiddleware<E> {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,
         handler: Handler<E>,

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -53,7 +53,11 @@ pub struct Route<B, E> {
     pub(crate) methods: Vec<Method>,
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Route<B, E> {
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Route<B, E>
+{
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,
         methods: Vec<Method>,

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -62,8 +62,10 @@ struct BuilderInner<B, E> {
     err_handler: Option<ErrHandler<B>>,
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterBuilder<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > RouterBuilder<B, E>
 {
     /// Creates a new `RouterBuilder` instance with default options.
     pub fn new() -> RouterBuilder<B, E> {
@@ -105,8 +107,10 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterBuilder<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > RouterBuilder<B, E>
 {
     /// Adds a new route with `GET` method and the handler at the specified path.
     ///
@@ -633,8 +637,10 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterBuilder<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > RouterBuilder<B, E>
 {
     /// Adds a single middleware. A pre middleware can be created by [`Middleware::pre`](./enum.Middleware.html#method.pre) method and a post
     /// middleware can be created by [`Middleware::post`](./enum.Middleware.html#method.post) method.
@@ -729,8 +735,10 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Default
-    for RouterBuilder<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Default for RouterBuilder<B, E>
 {
     fn default() -> RouterBuilder<B, E> {
         RouterBuilder {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -89,7 +89,11 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static> ErrHandler<B> {
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Router<B, E> {
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Router<B, E>
+{
     pub(crate) fn new(
         pre_middlewares: Vec<PreMiddleware<E>>,
         routes: Vec<Route<B, E>>,

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -12,17 +12,23 @@ pub struct RequestService<B, E> {
     pub(crate) remote_addr: SocketAddr,
 }
 
-unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Send
-    for RequestService<B, E>
+unsafe impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Send for RequestService<B, E>
 {
 }
-unsafe impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static> Sync
-    for RequestService<B, E>
+unsafe impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Sync for RequestService<B, E>
 {
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    Service<Request<hyper::Body>> for RequestService<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Service<Request<hyper::Body>> for RequestService<B, E>
 {
     type Response = Response<B>;
     type Error = crate::Error;

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -69,8 +69,10 @@ pub struct RouterService<B, E> {
     router: Router<B, E>,
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    RouterService<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > RouterService<B, E>
 {
     /// Creates a new service with the provided router and it's ready to be used with the hyper [`serve`](https://docs.rs/hyper/0.13.5/hyper/server/struct.Builder.html#method.serve)
     /// method.
@@ -207,8 +209,10 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + 
     }
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static, E: std::error::Error + Send + Sync + Unpin + 'static>
-    Service<&AddrStream> for RouterService<B, E>
+impl<
+        B: HttpBody + Send + Sync + Unpin + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    > Service<&AddrStream> for RouterService<B, E>
 {
     type Response = RequestService<B, E>;
     type Error = Infallible;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,6 +32,30 @@ async fn can_perform_simple_get_request() {
 }
 
 #[tokio::test]
+async fn can_perform_simple_get_request_boxed_error() {
+    const RESPONSE_TEXT: &str = "Hello world";
+    type BoxedError = Box<dyn std::error::Error + Sync + Send + 'static>;
+    let router: Router<Body, BoxedError> = Router::builder()
+        .get("/", |_| async move { Ok(Response::new(RESPONSE_TEXT.into())) })
+        .build()
+        .unwrap();
+    let serve = serve(router).await;
+    let resp = Client::new()
+        .request(
+            Request::builder()
+                .method("GET")
+                .uri(format!("http://{}/", serve.addr()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let resp = into_text(resp.into_body()).await;
+    assert_eq!(resp, RESPONSE_TEXT.to_owned());
+    serve.shutdown();
+}
+
+#[tokio::test]
 async fn can_respond_with_data_from_scope_state() {
     // Creating two modules containing separate state and routes which expose that state directly...
     mod service1 {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -30,9 +30,9 @@ impl Serve {
 pub async fn serve<B, E>(router: Router<B, E>) -> Serve
 where
     B: HttpBody + Send + Sync + Unpin + 'static,
-    E: std::error::Error + Send + Sync + Unpin + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
     <B as HttpBody>::Data: Send + Sync + 'static,
-    <B as HttpBody>::Error: std::error::Error + Send + Sync + 'static,
+    <B as HttpBody>::Error: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     let service = RouterService::new(router).unwrap();
     let server = Server::bind(&([127, 0, 0, 1], 0).into()).serve(service);


### PR DESCRIPTION
While porting a service from Hyper to Routerify I've encountered an issue of not being able to use a simple catch all `Box<dyn std::error::Error + Sync + Send + 'static>` as the handlers' and router error type, in order for the `?` operator to work. My workaround was to use `routerify::Error` as the error type and then `.map_err(|e| ...)?;`  in handlers. 

There are other possible workarounds, and one might reasonably suggest that the proper way would be to crate a custom Error type, possibly an enum, and then implement the `impl From` traits for all possible error, or use `thiserror` crate. However, I still think that being able to get away with just a trait error object or `anyhow::Error` is incredibly important for the convenience. A typical handler performs many things that can fail, from the string-num conversion, to json, to database access and calling third-party services. Being able to return all possible errors with the convenience of the `?` operator and without the need of creating a custom error type is a big deal in my opinion. 

This PR takes its inspiration from Hyper and relaxes the error trait bound to accept the error-like objects, like `Box<dyn Error + Sync + Send>` and `anyhow::Error`, which [do not implement](https://users.rust-lang.org/t/shouldnt-box-t-where-t-error-implement-error-regardless-whether-t-sized/48605) `std::error::Error`. To the best of my knowledge and after testing it with `rouetrify::Error`, `Box<dyn std::error::Error + Sync + Send>`, `anyhow::Error` and `std::io::Error`, this change should not break any existing code.

@rousan I'm aware that you do not have much time for this project anymore, but, as the original designer, could you please take a look at the PR to make sure that these changes are reasonable and do not break any existing code that uses the router. Thanks! 