### PR TITLE
Add request context

### DIFF
--- a/src/ext/request.rs
+++ b/src/ext/request.rs
@@ -1,5 +1,5 @@
 use crate::data_map::SharedDataMap;
-use crate::types::{RequestMeta, RouteParams};
+use crate::types::{RequestContext, RequestMeta, RouteParams};
 use hyper::Request;
 use std::net::SocketAddr;
 
@@ -88,6 +88,39 @@ pub trait RequestExt {
     ///
     /// Please refer to the [Data and State Sharing](../index.html#data-and-state-sharing) for more info.
     fn data<T: Send + Sync + 'static>(&self) -> Option<&T>;
+
+    /// Access data in the request context.
+    fn context<T: Send + Sync + Clone + 'static>(&self) -> Option<T>;
+
+    /// Put data into the request context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use routerify::{Router, RouteParams, Middleware};
+    /// use routerify::ext::RequestExt;
+    /// use hyper::{Response, Request, Body};
+    /// # use std::convert::Infallible;
+    ///
+    /// # fn run() -> Router<Body, Infallible> {
+    /// let router = Router::builder()
+    ///     .middleware(Middleware::pre(|req: Request<Body>| async move {
+    ///         req.set_context("example".to_string());
+    ///
+    ///         Ok(req)
+    ///     }))
+    ///     .get("/hello", |req| async move {
+    ///         let text = req.context::<String>().unwrap();
+    ///
+    ///         Ok(Response::new(Body::from(format!("Hello from : {}", text))))
+    ///      })
+    ///      .build()
+    ///      .unwrap();
+    /// # router
+    /// # }
+    /// # run();
+    /// ```
+    fn set_context<T: Send + Sync + Clone + 'static>(&self, val: T);
 }
 
 impl RequestExt for Request<hyper::Body> {
@@ -122,5 +155,21 @@ impl RequestExt for Request<hyper::Body> {
         }
 
         return None;
+    }
+
+    fn context<T: Send + Sync + Clone + 'static>(&self) -> Option<T> {
+        let ctx = self
+            .extensions()
+            .get::<RequestContext>()
+            .expect("Context must be present");
+        ctx.get::<T>()
+    }
+
+    fn set_context<T: Send + Sync + Clone + 'static>(&self, val: T) {
+        let ctx = self
+            .extensions()
+            .get::<RequestContext>()
+            .expect("Context must be present");
+        ctx.set(val)
     }
 }

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -1,6 +1,6 @@
 use crate::helpers;
 use crate::router::Router;
-use crate::types::{RequestInfo, RequestMeta};
+use crate::types::{RequestContext, RequestInfo, RequestMeta};
 use hyper::{body::HttpBody, service::Service, Request, Response};
 use std::future::Future;
 use std::net::SocketAddr;
@@ -56,9 +56,13 @@ impl<
                 .should_gen_req_info
                 .expect("The `should_gen_req_info` flag in Router is not initialized");
 
+            let context = RequestContext::new();
+
             if should_gen_req_info {
-                req_info = Some(RequestInfo::new_from_req(&req));
+                req_info = Some(RequestInfo::new_from_req(&req, context.clone()));
             }
+
+            req.extensions_mut().insert(context);
 
             match router.process(target_path.as_str(), req, req_info.clone()).await {
                 Ok(resp) => crate::Result::Ok(resp),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,7 +1,9 @@
+pub(crate) use request_context::RequestContext;
 pub use request_info::RequestInfo;
 pub(crate) use request_meta::RequestMeta;
 pub use route_params::RouteParams;
 
+mod request_context;
 mod request_info;
 mod request_meta;
 mod route_params;

--- a/src/types/request_context.rs
+++ b/src/types/request_context.rs
@@ -1,0 +1,30 @@
+use crate::data_map::DataMap;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub(crate) struct RequestContext {
+    // Strictly speaking, there should be no need to protect
+    // the datamap because the context is per request,
+    // thus no concurrent access.
+    // However, the context must be mutable and shared
+    // via req_info to be accessible from post middleware
+    // and error handler. Which is only possible with
+    // wrapping it in Arc and locking.
+    inner: Arc<Mutex<DataMap>>,
+}
+
+impl RequestContext {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(DataMap::new())),
+        }
+    }
+
+    pub(crate) fn set<T: Send + Sync + Clone + 'static>(&self, val: T) {
+        self.inner.lock().unwrap().insert(val);
+    }
+
+    pub(crate) fn get<T: Send + Sync + Clone + 'static>(&self) -> Option<T> {
+        self.inner.lock().unwrap().get::<T>().map(|val| val.clone())
+    }
+}

--- a/src/types/request_info.rs
+++ b/src/types/request_info.rs
@@ -1,3 +1,4 @@
+use super::RequestContext;
 use crate::data_map::SharedDataMap;
 use hyper::{Body, HeaderMap, Method, Request, Uri, Version};
 use std::fmt::{self, Debug, Formatter};
@@ -11,6 +12,7 @@ use std::sync::Arc;
 pub struct RequestInfo {
     pub(crate) req_info_inner: Arc<RequestInfoInner>,
     pub(crate) shared_data_maps: Option<Box<Vec<SharedDataMap>>>,
+    pub(crate) context: RequestContext,
 }
 
 #[derive(Debug)]
@@ -22,7 +24,7 @@ pub(crate) struct RequestInfoInner {
 }
 
 impl RequestInfo {
-    pub(crate) fn new_from_req(req: &Request<Body>) -> Self {
+    pub(crate) fn new_from_req(req: &Request<Body>, ctx: RequestContext) -> Self {
         let inner = RequestInfoInner {
             headers: req.headers().clone(),
             method: req.method().clone(),
@@ -33,6 +35,7 @@ impl RequestInfo {
         RequestInfo {
             req_info_inner: Arc::new(inner),
             shared_data_maps: None,
+            context: ctx,
         }
     }
 
@@ -70,6 +73,44 @@ impl RequestInfo {
         }
 
         return None;
+    }
+
+    /// Access data from the request context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use routerify::{Router, RouteParams, Middleware, RequestInfo};
+    /// use routerify::ext::RequestExt;
+    /// use hyper::{Response, Request, Body};
+    /// # use std::convert::Infallible;
+    ///
+    /// # fn run() -> Router<Body, Infallible> {
+    /// let router = Router::builder()
+    ///     .middleware(Middleware::pre(|req: Request<Body>| async move {
+    ///         req.set_context("example".to_string());
+    ///
+    ///         Ok(req)
+    ///     }))
+    ///     .middleware(Middleware::post_with_info(|res, req_info: RequestInfo| async move {
+    ///         let text = req_info.context::<String>().unwrap();
+    ///         println!("text is {}", text);
+    ///
+    ///         Ok(res)
+    ///     }))
+    ///     .get("/hello", |req| async move {
+    ///         let text = req.context::<String>().unwrap();
+    ///
+    ///         Ok(Response::new(Body::from(format!("Hello from : {}", text))))
+    ///      })
+    ///      .build()
+    ///      .unwrap();
+    /// # router
+    /// # }
+    /// # run();
+    /// ```
+    pub fn context<T: Send + Sync + Clone + 'static>(&self) -> Option<T> {
+        self.context.get::<T>()
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 use self::support::{into_text, serve};
-use hyper::{Body, Client, Request, Response};
+use hyper::{Body, Client, Request, Response, StatusCode};
 use routerify::prelude::RequestExt;
-use routerify::Router;
+use routerify::{Middleware, RequestInfo, Router};
 use std::io;
 use std::sync::{Arc, Mutex};
 
@@ -119,6 +119,83 @@ async fn can_respond_with_data_from_scope_state() {
         .unwrap();
     assert_eq!(200, resp.status().as_u16());
     assert_eq!(into_text(resp.into_body()).await, "2");
+
+    serve.shutdown();
+}
+
+#[tokio::test]
+async fn can_propagate_request_context() {
+    use std::io;
+    #[derive(Debug, Clone, PartialEq)]
+    struct Id(u32);
+
+    let before = |req: Request<Body>| async move {
+        req.set_context(Id(42));
+        Ok(req)
+    };
+
+    let index = |req: Request<Body>| async move {
+        // Check `id` from `before()`.
+        let id = req.context::<Id>().unwrap();
+        assert_eq!(id, Id(42));
+
+        // Check that non-existent context value is None.
+        let none = req.context::<u64>();
+        assert!(none.is_none());
+
+        // Add a String value to the context.
+        req.set_context("index".to_string());
+
+        // Trigger this error in order to invoke
+        // the error handler.
+        Err(io::Error::new(io::ErrorKind::AddrInUse, "bogus error"))
+    };
+
+    let error_handler = |_err, req_info: RequestInfo| async move {
+        // Check `id` from `before()`.
+        let id = req_info.context::<Id>().unwrap();
+        assert_eq!(id, Id(42));
+
+        // Check String from `index()`.
+        let name = req_info.context::<String>().unwrap();
+        assert_eq!(name, "index");
+
+        Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from("Something went wrong"))
+            .unwrap()
+    };
+
+    let after = |res, req_info: RequestInfo| async move {
+        // Check `id` from `before()`.
+        let id = req_info.context::<Id>().unwrap();
+        assert_eq!(id, Id(42));
+
+        // Check String from `index()`.
+        let name = req_info.context::<String>().unwrap();
+        assert_eq!(name, "index");
+
+        Ok(res)
+    };
+
+    let router: Router<Body, std::io::Error> = Router::builder()
+        .middleware(Middleware::pre(before))
+        .middleware(Middleware::post_with_info(after))
+        .err_handler_with_info(error_handler)
+        .get("/", index)
+        .build()
+        .unwrap();
+    let serve = serve(router).await;
+    let _ = Client::new()
+        .request(
+            Request::builder()
+                .method("GET")
+                .uri(format!("http://{}/", serve.addr()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
     serve.shutdown();
 }


### PR DESCRIPTION
This PR adds per request context. The context is mutably accessible from pre middleware and handlers, and immutably from post middleware and error handler. The new API is modeled after the shared data API.  

Here's a quick demonstration solving a common problem of determining the duration of the request handling:

```rust
async fn before(req: Request<Body>) -> Result<Request<Body>, Error> {
    req.set_context(tokio::time::Instant::now());
    Ok(req)
}

async fn hello(_: Request<Body>) -> Result<Response<Body>, Error> {
    Ok(Response::new(Body::from("Home page")))
}

async fn after(res: Response<Body>, req_info: RequestInfo) -> Result<Response<Body>, Error> {
    let started = req_info.context::<tokio::time::Instant>().unwrap();
    let duration = started.elapsed();
    println!("duration {:?}", duration);
    Ok(res)
}

fn router() -> Router<Body, Error> {
    Router::builder()
        .get("/", hello)
        .middleware(Middleware::pre(before))
        .middleware(Middleware::post_with_info(after))
        .build()
        .unwrap()
}
```

Another common problem that is easily solved with the context is authenticating a user in a middleware and storing the user id or some other auth into in the context to be accessible in the handler.

Similar to shared data, the internal mechanism relies on `http`'s `Extensions`. The context is accessible via the `Request` object in pre middleware and handlers, and via `RequestInfo` in post middleware and error handler. One difference from shared data is that values must be clonable, thus it's preferred to use values that are relatively cheap to clone.

@rousan @NikosEfthias let me know what you think, guys. If this is a reasonable approach, then I will also add examples in the follow-up PR.