### PR TITLE
Make Router immutable and use Arc<Router> instead of unsafe in RequestService.

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -50,7 +50,7 @@ impl<
     /// ```
     pub fn pre<H, R>(handler: H) -> Middleware<B, E>
     where
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Request<hyper::Body>, E>> + Send + 'static,
     {
         Middleware::pre_with_path("/*", handler).unwrap()
@@ -76,7 +76,7 @@ impl<
     /// ```
     pub fn post<H, R>(handler: H) -> Middleware<B, E>
     where
-        H: FnMut(Response<B>) -> R + Send + Sync + 'static,
+        H: Fn(Response<B>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         Middleware::post_with_path("/*", handler).unwrap()
@@ -111,7 +111,7 @@ impl<
     /// ```
     pub fn post_with_info<H, R>(handler: H) -> Middleware<B, E>
     where
-        H: FnMut(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
+        H: Fn(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         Middleware::post_with_info_with_path("/*", handler).unwrap()
@@ -138,7 +138,7 @@ impl<
     pub fn pre_with_path<P, H, R>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Request<hyper::Body>, E>> + Send + 'static,
     {
         Ok(Middleware::Pre(PreMiddleware::new(path, handler)?))
@@ -165,7 +165,7 @@ impl<
     pub fn post_with_path<P, H, R>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
     where
         P: Into<String>,
-        H: FnMut(Response<B>) -> R + Send + Sync + 'static,
+        H: Fn(Response<B>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         Ok(Middleware::Post(PostMiddleware::new(path, handler)?))
@@ -201,7 +201,7 @@ impl<
     pub fn post_with_info_with_path<P, H, R>(path: P, handler: H) -> crate::Result<Middleware<B, E>>
     where
         P: Into<String>,
-        H: FnMut(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
+        H: Fn(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         Ok(Middleware::Post(PostMiddleware::new_with_info(path, handler)?))

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -26,8 +26,8 @@ pub enum Middleware<B, E> {
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > Middleware<B, E>
 {
     /// Creates a pre middleware with a handler at the `/*` path.

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -7,11 +7,11 @@ use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
 
-type HandlerWithoutInfo<B, E> = Box<dyn FnMut(Response<B>) -> HandlerWithoutInfoReturn<B, E> + Send + Sync + 'static>;
+type HandlerWithoutInfo<B, E> = Box<dyn Fn(Response<B>) -> HandlerWithoutInfoReturn<B, E> + Send + Sync + 'static>;
 type HandlerWithoutInfoReturn<B, E> = Box<dyn Future<Output = Result<Response<B>, E>> + Send + 'static>;
 
 type HandlerWithInfo<B, E> =
-    Box<dyn FnMut(Response<B>, RequestInfo) -> HandlerWithInfoReturn<B, E> + Send + Sync + 'static>;
+    Box<dyn Fn(Response<B>, RequestInfo) -> HandlerWithInfoReturn<B, E> + Send + Sync + 'static>;
 type HandlerWithInfoReturn<B, E> = Box<dyn Future<Output = Result<Response<B>, E>> + Send + 'static>;
 
 /// The post middleware type. Refer to [Post Middleware](./index.html#post-middleware) for more info.
@@ -72,10 +72,10 @@ impl<
     /// # }
     /// # run();
     /// ```
-    pub fn new<P, H, R>(path: P, mut handler: H) -> crate::Result<PostMiddleware<B, E>>
+    pub fn new<P, H, R>(path: P, handler: H) -> crate::Result<PostMiddleware<B, E>>
     where
         P: Into<String>,
-        H: FnMut(Response<B>) -> R + Send + Sync + 'static,
+        H: Fn(Response<B>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         let handler: HandlerWithoutInfo<B, E> = Box::new(move |res: Response<B>| Box::new(handler(res)));
@@ -109,10 +109,10 @@ impl<
     /// # }
     /// # run();
     /// ```
-    pub fn new_with_info<P, H, R>(path: P, mut handler: H) -> crate::Result<PostMiddleware<B, E>>
+    pub fn new_with_info<P, H, R>(path: P, handler: H) -> crate::Result<PostMiddleware<B, E>>
     where
         P: Into<String>,
-        H: FnMut(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
+        H: Fn(Response<B>, RequestInfo) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         let handler: HandlerWithInfo<B, E> =
@@ -132,20 +132,20 @@ impl<
     }
 
     pub(crate) async fn process(
-        &mut self,
+        &self,
         res: Response<B>,
         req_info: Option<RequestInfo>,
     ) -> crate::Result<Response<B>> {
         let handler = self
             .handler
-            .as_mut()
+            .as_ref()
             .expect("A router can not be used after mounting into another router");
 
         match handler {
-            Handler::WithoutInfo(ref mut handler) => Pin::from(handler(res))
+            Handler::WithoutInfo(ref handler) => Pin::from(handler(res))
                 .await
                 .map_err(|e| Error::HandlePostMiddlewareWithoutInfoRequest(e.into())),
-            Handler::WithInfo(ref mut handler) => {
+            Handler::WithInfo(ref handler) => {
                 Pin::from(handler(res, req_info.expect("No RequestInfo is provided")))
                     .await
                     .map_err(|e| Error::HandlePostMiddlewareWithInfoRequest(e.into()))

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -36,8 +36,8 @@ pub(crate) enum Handler<B, E> {
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > PostMiddleware<B, E>
 {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -22,7 +22,7 @@ pub struct PreMiddleware<E> {
     pub(crate) handler: Option<Handler<E>>,
 }
 
-impl<E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static> PreMiddleware<E> {
+impl<E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static> PreMiddleware<E> {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,
         handler: Handler<E>,

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -54,8 +54,8 @@ pub struct Route<B, E> {
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > Route<B, E>
 {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -63,8 +63,8 @@ struct BuilderInner<B, E> {
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > RouterBuilder<B, E>
 {
     /// Creates a new `RouterBuilder` instance with default options.
@@ -108,8 +108,8 @@ impl<
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > RouterBuilder<B, E>
 {
     /// Adds a new route with `GET` method and the handler at the specified path.
@@ -638,8 +638,8 @@ impl<
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > RouterBuilder<B, E>
 {
     /// Adds a single middleware. A pre middleware can be created by [`Middleware::pre`](./enum.Middleware.html#method.pre) method and a post
@@ -736,8 +736,8 @@ impl<
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > Default for RouterBuilder<B, E>
 {
     fn default() -> RouterBuilder<B, E> {

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -136,7 +136,7 @@ impl<
     pub fn get<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::GET], handler)
@@ -166,7 +166,7 @@ impl<
     pub fn get_or_head<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::GET, Method::HEAD], handler)
@@ -196,7 +196,7 @@ impl<
     pub fn post<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::POST], handler)
@@ -226,7 +226,7 @@ impl<
     pub fn put<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::PUT], handler)
@@ -256,7 +256,7 @@ impl<
     pub fn delete<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::DELETE], handler)
@@ -286,7 +286,7 @@ impl<
     pub fn head<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::HEAD], handler)
@@ -316,7 +316,7 @@ impl<
     pub fn trace<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::TRACE], handler)
@@ -346,7 +346,7 @@ impl<
     pub fn connect<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::CONNECT], handler)
@@ -376,7 +376,7 @@ impl<
     pub fn patch<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::PATCH], handler)
@@ -406,7 +406,7 @@ impl<
     pub fn options<P, H, R>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, vec![Method::OPTIONS], handler)
@@ -446,7 +446,7 @@ impl<
     /// ```
     pub fn any<H, R>(self, handler: H) -> Self
     where
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add("/*", constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), handler)
@@ -477,7 +477,7 @@ impl<
     pub fn any_method<H, R, P>(self, path: P, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.add(path, constants::ALL_POSSIBLE_HTTP_METHODS.to_vec(), handler)
@@ -507,7 +507,7 @@ impl<
     pub fn add<P, H, R>(self, path: P, methods: Vec<Method>, handler: H) -> Self
     where
         P: Into<String>,
-        H: FnMut(Request<hyper::Body>) -> R + Send + Sync + 'static,
+        H: Fn(Request<hyper::Body>) -> R + Send + Sync + 'static,
         R: Future<Output = Result<Response<B>, E>> + Send + 'static,
     {
         self.and_then(move |mut inner| {
@@ -701,9 +701,9 @@ impl<
 
     /// Adds a handler to handle any error raised by the routes or any middlewares. Please refer to [Error Handling](./index.html#error-handling) section
     /// for more info.
-    pub fn err_handler<H, R>(self, mut handler: H) -> Self
+    pub fn err_handler<H, R>(self, handler: H) -> Self
     where
-        H: FnMut(crate::Error) -> R + Send + Sync + 'static,
+        H: Fn(crate::Error) -> R + Send + Sync + 'static,
         R: Future<Output = Response<B>> + Send + 'static,
     {
         let handler: ErrHandlerWithoutInfo<B> = Box::new(move |err: crate::Error| Box::new(handler(err)));
@@ -720,9 +720,9 @@ impl<
     ///
     /// Please refer to [Error Handling](./index.html#error-handling) section
     /// for more info.
-    pub fn err_handler_with_info<H, R>(self, mut handler: H) -> Self
+    pub fn err_handler_with_info<H, R>(self, handler: H) -> Self
     where
-        H: FnMut(crate::Error, RequestInfo) -> R + Send + Sync + 'static,
+        H: Fn(crate::Error, RequestInfo) -> R + Send + Sync + 'static,
         R: Future<Output = Response<B>> + Send + 'static,
     {
         let handler: ErrHandlerWithInfo<B> =

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -78,7 +78,7 @@ pub(crate) enum ErrHandler<B> {
     WithInfo(ErrHandlerWithInfo<B>),
 }
 
-impl<B: HttpBody + Send + Sync + Unpin + 'static> ErrHandler<B> {
+impl<B: HttpBody + Send + Sync + 'static> ErrHandler<B> {
     pub(crate) async fn execute(&self, err: crate::Error, req_info: Option<RequestInfo>) -> Response<B> {
         match self {
             ErrHandler::WithoutInfo(ref err_handler) => Pin::from(err_handler(err)).await,
@@ -90,8 +90,8 @@ impl<B: HttpBody + Send + Sync + Unpin + 'static> ErrHandler<B> {
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > Router<B, E>
 {
     pub(crate) fn new(

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -14,11 +14,11 @@ pub use self::builder::RouterBuilder;
 mod builder;
 
 pub(crate) type ErrHandlerWithoutInfo<B> =
-    Box<dyn FnMut(crate::Error) -> ErrHandlerWithoutInfoReturn<B> + Send + Sync + 'static>;
+    Box<dyn Fn(crate::Error) -> ErrHandlerWithoutInfoReturn<B> + Send + Sync + 'static>;
 pub(crate) type ErrHandlerWithoutInfoReturn<B> = Box<dyn Future<Output = Response<B>> + Send + 'static>;
 
 pub(crate) type ErrHandlerWithInfo<B> =
-    Box<dyn FnMut(crate::Error, RequestInfo) -> ErrHandlerWithInfoReturn<B> + Send + Sync + 'static>;
+    Box<dyn Fn(crate::Error, RequestInfo) -> ErrHandlerWithInfoReturn<B> + Send + Sync + 'static>;
 pub(crate) type ErrHandlerWithInfoReturn<B> = Box<dyn Future<Output = Response<B>> + Send + 'static>;
 
 /// Represents a modular, lightweight and mountable router type.
@@ -79,10 +79,10 @@ pub(crate) enum ErrHandler<B> {
 }
 
 impl<B: HttpBody + Send + Sync + Unpin + 'static> ErrHandler<B> {
-    pub(crate) async fn execute(&mut self, err: crate::Error, req_info: Option<RequestInfo>) -> Response<B> {
+    pub(crate) async fn execute(&self, err: crate::Error, req_info: Option<RequestInfo>) -> Response<B> {
         match self {
-            ErrHandler::WithoutInfo(ref mut err_handler) => Pin::from(err_handler(err)).await,
-            ErrHandler::WithInfo(ref mut err_handler) => {
+            ErrHandler::WithoutInfo(ref err_handler) => Pin::from(err_handler(err)).await,
+            ErrHandler::WithInfo(ref err_handler) => {
                 Pin::from(err_handler(err, req_info.expect("No RequestInfo is provided"))).await
             }
         }
@@ -148,7 +148,7 @@ impl<
     }
 
     pub(crate) async fn process(
-        &mut self,
+        &self,
         target_path: &str,
         mut req: Request<hyper::Body>,
         mut req_info: Option<RequestInfo>,
@@ -176,14 +176,14 @@ impl<
 
         let mut transformed_req = req;
         for idx in matched_pre_middleware_idxs {
-            let pre_middleware = &mut self.pre_middlewares[idx];
+            let pre_middleware = &self.pre_middlewares[idx];
 
             transformed_req = pre_middleware.process(transformed_req).await?;
         }
 
         let mut resp = None;
         for idx in matched_route_idxs {
-            let route = &mut self.routes[idx];
+            let route = &self.routes[idx];
 
             if route.is_match_method(transformed_req.method()) {
                 let route_resp_res = route.process(target_path, transformed_req).await;
@@ -191,7 +191,7 @@ impl<
                 let route_resp = match route_resp_res {
                     Ok(route_resp) => route_resp,
                     Err(err) => {
-                        if let Some(ref mut err_handler) = self.err_handler {
+                        if let Some(ref err_handler) = self.err_handler {
                             err_handler.execute(err, req_info.clone()).await
                         } else {
                             return Err(err);
@@ -210,7 +210,7 @@ impl<
 
         let mut transformed_res = resp.unwrap();
         for idx in matched_post_middleware_idxs {
-            let post_middleware = &mut self.post_middlewares[idx];
+            let post_middleware = &self.post_middlewares[idx];
             transformed_res = post_middleware.process(transformed_res, req_info.clone()).await?;
         }
 

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -16,6 +16,7 @@ use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::sync::Arc;
 
 /// A [`Service`](https://docs.rs/hyper/0.13.5/hyper/service/trait.Service.html) to process incoming requests.
 ///
@@ -66,12 +67,12 @@ use std::task::{Context, Poll};
 /// ```
 #[derive(Debug)]
 pub struct RouterService<B, E> {
-    router: Router<B, E>,
+    router: Arc<Router<B, E>>,
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > RouterService<B, E>
 {
     /// Creates a new service with the provided router and it's ready to be used with the hyper [`serve`](https://docs.rs/hyper/0.13.5/hyper/server/struct.Builder.html#method.serve)
@@ -88,7 +89,7 @@ impl<
         router.init_regex_set()?;
         router.init_req_info_gen();
 
-        Ok(RouterService { router })
+        Ok(RouterService { router: Arc::new(router) })
     }
 
     fn init_router_with_x_powered_by_middleware(router: &mut Router<B, E>) {
@@ -210,8 +211,8 @@ impl<
 }
 
 impl<
-        B: HttpBody + Send + Sync + Unpin + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+        B: HttpBody + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     > Service<&AddrStream> for RouterService<B, E>
 {
     type Response = RequestService<B, E>;
@@ -226,7 +227,7 @@ impl<
         let remote_addr = conn.remote_addr();
 
         let req_service = RequestService {
-            router: &self.router,
+            router: self.router.clone(),
             remote_addr,
         };
 

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -226,7 +226,7 @@ impl<
         let remote_addr = conn.remote_addr();
 
         let req_service = RequestService {
-            router: &mut self.router,
+            router: &self.router,
             remote_addr,
         };
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -29,8 +29,8 @@ impl Serve {
 
 pub async fn serve<B, E>(router: Router<B, E>) -> Serve
 where
-    B: HttpBody + Send + Sync + Unpin + 'static,
-    E: Into<Box<dyn std::error::Error + Send + Sync>> + Unpin + 'static,
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
     <B as HttpBody>::Data: Send + Sync + 'static,
     <B as HttpBody>::Error: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {


### PR DESCRIPTION
This PR is based on awesome work by @cpcloud in https://github.com/routerify/routerify/pull/25. I think that the perf drop mentioned in https://github.com/routerify/routerify/pull/25/files#discussion_r527962151 was mostly due to `Mutex` which was effectively making router single-threaded.

I've managed to find a way to make router immutable by changing `FnMut` trait bounds to `Fn`. I see absolutely no reason why a handler or middleware would need to mutably capture their environment. I'm actually not sure that that's even possible with `Send + Sync + 'static` and threads. Now, with the `Router` instance being immutable, there's no need to use `Mutex`; wrapping only in `Arc` is enough for sharing the router.

Of course, there's still *some* price associated with `Arc`, but it's definitely much less than `Arc<Mutex>` and I'm convinced that it's totally worth it for getting rid of the unsafe code.