### PR TITLE
Request context doc and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@
 
 To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper](https://hyper.rs/), please check out [hyper-routerify-server-template](https://github.com/routerify/hyper-routerify-server-template).
 
+## Benchmarks
+
+| Framework      | Language    | Requests/sec |
+|----------------|-------------|--------------|
+| [hyper v0.14](https://github.com/hyperium/hyper) | Rust 1.50.0 | 144,583 |
+| [routerify v2.0.0-beta-4](https://github.com/routerify/routerify) with [hyper v0.14](https://github.com/hyperium/hyper) | Rust 1.50.0 | 144,621 |
+| [actix-web v3](https://github.com/actix/actix-web) | Rust 1.50.0 | 131,292 |
+| [warp v0.3](https://github.com/seanmonstar/warp) | Rust 1.50.0 | 145,362 |
+| [go-httprouter, branch master](https://github.com/julienschmidt/httprouter) | Go 1.16 | 130,662 |
+| [Rocket, branch master](https://github.com/SergioBenitez/Rocket) | Rust 1.50.0 | 130,045 |
+
+For more info, please visit [Benchmarks](https://github.com/routerify/routerify-benchmark).
+
 ## Install
 
 Add this to your `Cargo.toml` file:

--- a/README.md
+++ b/README.md
@@ -14,40 +14,22 @@
 
 # Routerify
 
-The `Routerify` provides a lightweight, idiomatic, composable and modular router implementation with middleware support for the Rust HTTP library [hyper.rs](https://hyper.rs/).
+`Routerify` provides a lightweight, idiomatic, composable and modular router implementation with middleware support for the Rust HTTP library [hyper](https://hyper.rs/).
 
-There are a lot of web server frameworks for Rust applications out there and [hyper.rs](https://hyper.rs/) being comparably very fast and ready for production use
-is one of them, and it provides only low level API. It doesn't provide any complex routing feature. So, `Routerify` extends the [hyper.rs](https://hyper.rs/) library
-by providing that missing feature without compromising any performance.
-
-The `Routerify` offers the following features:
+`Routerify` offers the following features:
 
 - 📡 Allows defining complex routing logic.
 - 🔨 Provides middleware support.
 - 🌀 Supports Route Parameters.
-- 🚀 Fast as it's using [`RegexSet`](https://docs.rs/regex/1.3.7/regex/struct.RegexSet.html) to match routes. 
-- 🍺 It supports any response body type as long as it implements the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait.
+- 🚀 Fast as it's using [`RegexSet`](https://docs.rs/regex/1.4.3/regex/struct.RegexSet.html) to match routes. 
+- 🍺 It supports any response body type as long as it implements the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait.
 - ❗ Provides a flexible error handling strategy.
 - 💁 Provides `WebSocket` [support](https://github.com/routerify/routerify-websocket) out of the box.
 - 🔥 Allows data/state sharing across the route and middleware handlers.
 - 🍗 Exhaustive [examples](https://github.com/routerify/routerify/tree/master/examples) and well documented.
 
 
-To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper.rs](https://hyper.rs/), please check out [hyper-routerify-server-template](https://github.com/routerify/hyper-routerify-server-template).
-
-## Benchmarks
-
-| Framework      | Language    | Requests/sec |
-|----------------|-------------|--------------|
-| [hyper v0.13](https://github.com/hyperium/hyper) | Rust 1.43.0 | 112,557 |
-| [routerify v1.1](https://github.com/routerify/routerify) with [hyper v0.13](https://github.com/hyperium/hyper) | Rust 1.43.0 | 112,320 |
-| [gotham v0.4.0](https://github.com/gotham-rs/gotham) | Rust 1.43.0 | 100,097 |
-| [actix-web v2](https://github.com/actix/actix-web) | Rust 1.43.0 | 96,397 |
-| [warp v0.2](https://github.com/seanmonstar/warp) | Rust 1.43.0 | 81,912 |
-| [go-httprouter, branch master](https://github.com/julienschmidt/httprouter) | Go 1.13.7 | 74,958 |
-| [Rocket, branch async](https://github.com/SergioBenitez/Rocket) | Rust 1.43.0 | 2,041 ? |
-
-For more info, please visit [Benchmarks](https://github.com/routerify/routerify-benchmark).
+To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper](https://hyper.rs/), please check out [hyper-routerify-server-template](https://github.com/routerify/hyper-routerify-server-template).
 
 ## Install
 
@@ -56,11 +38,13 @@ Add this to your `Cargo.toml` file:
 ```toml
 [dependencies]
 routerify = "2.0.0-beta-4"
+hyper = "0.14"
+tokio = { version = "1", features = ["full"] }
 ```
 
 ## Basic Example
 
-A simple example using `Routerify` with [hyper.rs](https://hyper.rs/) would look like the following:
+A simple example using `Routerify` with `hyper` would look like the following:
 
 ```rust
 use hyper::{Body, Request, Response, Server, StatusCode};

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,4 +26,4 @@ Run an example:
 
 * [`scoped_router`](scoped_router.rs) - Shows how to write modular routing logic by mounting a router on another router.
 
-* [`using_stream_body`](using_stream_body.rs) - An example on how to use a different response body type ([StreamBody](https://github.com/rousan/stream-body)) other than `hyper::Body`.
+* [`request_duration`](request_duration.rs) - Shows how to measure the duration of a request using per request context and middleware.

--- a/examples/request_duration.rs
+++ b/examples/request_duration.rs
@@ -1,0 +1,50 @@
+use hyper::{Body, Request, Response, Server};
+// Import the routerify prelude traits.
+use routerify::prelude::*;
+use routerify::{Router, RouterService, Middleware, RequestInfo};
+use std::net::SocketAddr;
+use std::convert::Infallible;
+
+async fn before(req: Request<Body>) -> Result<Request<Body>, Infallible> {
+    req.set_context(tokio::time::Instant::now());
+    Ok(req)
+}
+
+async fn hello(_: Request<Body>) -> Result<Response<Body>, Infallible> {
+    Ok(Response::new(Body::from("Home page")))
+}
+
+async fn after(res: Response<Body>, req_info: RequestInfo) -> Result<Response<Body>, Infallible> {
+    let started = req_info.context::<tokio::time::Instant>().unwrap();
+    let duration = started.elapsed();
+    println!("duration {:?}", duration);
+    Ok(res)
+}
+
+fn router() -> Router<Body, Infallible> {
+    Router::builder()
+        .get("/", hello)
+        .middleware(Middleware::pre(before))
+        .middleware(Middleware::post_with_info(after))
+        .build()
+        .unwrap()
+}
+
+#[tokio::main]
+async fn main() {
+    let router = router();
+
+    // Create a Service from the router above to handle incoming requests.
+    let service = RouterService::new(router).unwrap();
+
+    // The address on which the server will be listening.
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+
+    // Create a server by passing the created service to `.serve` method.
+    let server = Server::bind(&addr).serve(service);
+
+    println!("App is running on: {}", addr);
+    if let Err(err) = server.await {
+        eprintln!("Server error: {}", err);
+    }
+}

--- a/src/ext/request.rs
+++ b/src/ext/request.rs
@@ -3,7 +3,7 @@ use crate::types::{RequestContext, RequestMeta, RouteParams};
 use hyper::Request;
 use std::net::SocketAddr;
 
-/// A extension trait which extends the [`hyper::Request`](https://docs.rs/hyper/0.13.5/hyper/struct.Request.html) type with some helpful methods.
+/// A extension trait which extends the [`hyper::Request`](https://docs.rs/hyper/0.14.4/hyper/struct.Request.html) type with some helpful methods.
 pub trait RequestExt {
     /// It returns the route parameters as [RouteParams](../struct.RouteParams.html) type with the name of the parameter specified in the path as their respective keys.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,20 @@
 //! To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper](https://hyper.rs/),
 //! please check out [hyper-routerify-server-template](https://github.com/routerify/hyper-routerify-server-template).
 //!
+//!
+//! ## Benchmarks
+//!
+//! | Framework      | Language    | Requests/sec |
+//! |----------------|-------------|--------------|
+//! | [hyper v0.14](https://github.com/hyperium/hyper) | Rust 1.50.0 | 144,583 |
+//! | [routerify v2.0.0-beta-4](https://github.com/routerify/routerify) with [hyper v0.14](https://github.com/hyperium/hyper) | Rust 1.50.0 | 144,621 |
+//! | [actix-web v3](https://github.com/actix/actix-web) | Rust 1.50.0 | 131,292 |
+//! | [warp v0.3](https://github.com/seanmonstar/warp) | Rust 1.50.0 | 145,362 |
+//! | [go-httprouter, branch master](https://github.com/julienschmidt/httprouter) | Go 1.16 | 130,662 |
+//! | [Rocket, branch master](https://github.com/SergioBenitez/Rocket) | Rust 1.50.0 | 130,045 |
+//!
+//! For more info, please visit [Benchmarks](https://github.com/routerify/routerify-benchmark).
+//!
 //! ## Basic Example
 //!
 //! A simple example using `Routerify` with `hyper` would look like the following:
@@ -678,7 +692,7 @@
 //! ```
 //!
 //! ### Request context
-//! 
+//!
 //! It's possible to share data local to the request across the route handlers and middleware via the
 //! [`RequestExt`](./ext/trait.RequestExt.html) methods [`context`](./ext/trait.RequestExt.html#method.context)
 //! and [`set_context`](./ext/trait.RequestExt.html#method.set_context). In the error handler it can be accessed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
-//! The `Routerify` provides a lightweight, idiomatic, composable and modular router implementation with middleware support for the Rust HTTP library [hyper.rs](https://hyper.rs/).
+//! `Routerify` provides a lightweight, idiomatic, composable and modular router implementation with middleware support for the Rust HTTP library [hyper](https://hyper.rs/).
 //!
-//! There are a lot of web server frameworks for Rust applications out there and [hyper.rs](https://hyper.rs/) being comparably very fast and ready for production use
-//! is one of them, and it provides only low level APIs. It doesn't provide any complex routing feature. So, `Routerify` extends the [hyper.rs](https://hyper.rs/) library
-//! by providing that missing feature without compromising any performance.
-//!
-//! The `Routerify` offers the following features:
+//! `Routerify` offers the following features:
 //!
 //! - 📡 Allows defining complex routing logic.
 //!
@@ -12,9 +8,9 @@
 //!
 //! - 🌀 Supports Route Parameters.
 //!
-//! - 🚀 Fast as it's using [`RegexSet`](https://docs.rs/regex/1.3.7/regex/struct.RegexSet.html) to match routes.
+//! - 🚀 Fast as it's using [`RegexSet`](https://docs.rs/regex/1.4.3/regex/struct.RegexSet.html) to match routes.
 //!
-//! - 🍺 It supports any response body type as long as it implements the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait.
+//! - 🍺 It supports any response body type as long as it implements the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait.
 //!
 //! - ❗ Provides a flexible [error handling](./index.html#error-handling) strategy.
 //!
@@ -24,26 +20,12 @@
 //!
 //! - 🍗 Exhaustive [examples](https://github.com/routerify/routerify/tree/master/examples) and well documented.
 //!
-//! To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper.rs](https://hyper.rs/),
+//! To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper](https://hyper.rs/),
 //! please check out [hyper-routerify-server-template](https://github.com/routerify/hyper-routerify-server-template).
-//!
-//! ## Benchmarks
-//!
-//! | Framework      | Language    | Requests/sec |
-//! |----------------|-------------|--------------|
-//! | [hyper v0.13](https://github.com/hyperium/hyper) | Rust 1.43.0 | 112,557 |
-//! | [routerify v1.1](https://github.com/routerify/routerify) with [hyper v0.13](https://github.com/hyperium/hyper) | Rust 1.43.0 | 112,320 |
-//! | [gotham v0.4.0](https://github.com/gotham-rs/gotham) | Rust 1.43.0 | 100,097 |
-//! | [actix-web v2](https://github.com/actix/actix-web) | Rust 1.43.0 | 96,397 |
-//! | [warp v0.2](https://github.com/seanmonstar/warp) | Rust 1.43.0 | 81,912 |
-//! | [go-httprouter, branch master](https://github.com/julienschmidt/httprouter) | Go 1.13.7 | 74,958 |
-//! | [Rocket, branch async](https://github.com/SergioBenitez/Rocket) | Rust 1.43.0 | 2,041 ? |
-//!
-//! For more info, please visit [Benchmarks](https://github.com/routerify/routerify-benchmark).
 //!
 //! ## Basic Example
 //!
-//! A simple example using `Routerify` with [hyper.rs](https://hyper.rs/) would look like the following:
+//! A simple example using `Routerify` with `hyper` would look like the following:
 //!
 //! ```no_run
 //! use hyper::{Body, Request, Response, Server, StatusCode};
@@ -479,7 +461,7 @@
 //! # run();
 //! ```
 //!
-//! ### The built-in Middlewars
+//! ### The built-in Middleware
 //!
 //! Here is a list of some middlewares which are published in different crates:
 //!
@@ -488,7 +470,7 @@
 //!
 //! ## Data and State Sharing
 //!
-//! The `Routerify` also allows you to share data or app state across the route handlers, middlewares and the error handler via the [`RouterBuilder`](./struct.RouterBuilder.html) method
+//! `Routerify` also allows you to share data or app state across the route handlers, middlewares and the error handler via the [`RouterBuilder`](./struct.RouterBuilder.html) method
 //! [`data`](./struct.RouterBuilder.html#method.data). As it provides composable router API, it also allows to have app state/data per each sub-router.
 //!
 //! Here is an example to share app state:
@@ -695,9 +677,16 @@
 //! }
 //! ```
 //!
+//! ### Request context
+//! 
+//! It's possible to share data local to the request across the route handlers and middleware via the
+//! [`RequestExt`](./ext/trait.RequestExt.html) methods [`context`](./ext/trait.RequestExt.html#method.context)
+//! and [`set_context`](./ext/trait.RequestExt.html#method.set_context). In the error handler it can be accessed
+//! via [`RequestInfo`](./struct.RequestInfo.html) method [`context`](./struct.RequestInfo.html#method.context).
+//!
 //! ## Error Handling
 //!
-//! Any route or middleware could go wrong and throws an error. The `Routerify` tries to add a default error handler in some cases. But, it also
+//! Any route or middleware could go wrong and throws an error. `Routerify` tries to add a default error handler in some cases. But, it also
 //! allow to attach a custom error handler. The error handler generates a response based on the error and the request info(optional).
 //!
 //! Here is an basic example:
@@ -730,7 +719,7 @@
 //!
 //! ### Error Handling with Request Info
 //!
-//! Sometimes, it's needed to to generate response on error based on the request headers, method, uri etc. The `Routerify` also provides a method [`err_handler_with_info`](./struct.RouterBuilder.html#method.err_handler_with_info)
+//! Sometimes, it's needed to to generate response on error based on the request headers, method, uri etc. `Routerify` also provides a method [`err_handler_with_info`](./struct.RouterBuilder.html#method.err_handler_with_info)
 //! to register this kind of error handler as follows:
 //!
 //! ```

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -13,7 +13,7 @@ mod pre;
 /// This `Middleware<B, E>` type accepts two type parameters: `B` and `E`.
 ///
 /// * The `B` represents the response body type which will be used by route handlers and the middlewares and this body type must implement
-///   the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.13.5/hyper/body/struct.Body.html)
+///   the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.14.4/hyper/body/struct.Body.html)
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 #[derive(Debug)]

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -19,7 +19,7 @@ type HandlerWithInfoReturn<B, E> = Box<dyn Future<Output = Result<Response<B>, E
 /// This `PostMiddleware<B, E>` type accepts two type parameters: `B` and `E`.
 ///
 /// * The `B` represents the response body type which will be used by route handlers and the middlewares and this body type must implement
-///   the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.13.5/hyper/body/struct.Body.html)
+///   the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.14.4/hyper/body/struct.Body.html)
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 pub struct PostMiddleware<B, E> {

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -19,7 +19,7 @@ type HandlerReturn<B, E> = Box<dyn Future<Output = Result<Response<B>, E>> + Sen
 /// This `Route<B, E>` type accepts two type parameters: `B` and `E`.
 ///
 /// * The `B` represents the response body type which will be used by route handlers and the middlewares and this body type must implement
-///   the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.13.5/hyper/body/struct.Body.html)
+///   the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.14.4/hyper/body/struct.Body.html)
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 ///

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 /// This `RouterBuilder<B, E>` type accepts two type parameters: `B` and `E`.
 ///
 /// * The `B` represents the response body type which will be used by route handlers and the middlewares and this body type must implement
-///   the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.13.5/hyper/body/struct.Body.html)
+///   the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.14.4/hyper/body/struct.Body.html)
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 ///

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -28,7 +28,7 @@ pub(crate) type ErrHandlerWithInfoReturn<B> = Box<dyn Future<Output = Response<B
 /// This `Router<B, E>` type accepts two type parameters: `B` and `E`.
 ///
 /// * The `B` represents the response body type which will be used by route handlers and the middlewares and this body type must implement
-///   the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.13.5/hyper/body/struct.Body.html)
+///   the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.14.4/hyper/body/struct.Body.html)
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 ///

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -18,12 +18,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-/// A [`Service`](https://docs.rs/hyper/0.13.5/hyper/service/trait.Service.html) to process incoming requests.
+/// A [`Service`](https://docs.rs/hyper/0.14.4/hyper/service/trait.Service.html) to process incoming requests.
 ///
 /// This `RouterService<B, E>` type accepts two type parameters: `B` and `E`.
 ///
 /// * The `B` represents the response body type which will be used by route handlers and the middlewares and this body type must implement
-///   the [HttpBody](https://docs.rs/hyper/0.13.5/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.13.5/hyper/body/struct.Body.html)
+///   the [HttpBody](https://docs.rs/hyper/0.14.4/hyper/body/trait.HttpBody.html) trait. For an instance, `B` could be [hyper::Body](https://docs.rs/hyper/0.14.4/hyper/body/struct.Body.html)
 ///   type.
 /// * The `E` represents any error type which will be used by route handlers and the middlewares. This error type must implement the [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
 ///
@@ -73,7 +73,7 @@ pub struct RouterService<B, E> {
 impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
     RouterService<B, E>
 {
-    /// Creates a new service with the provided router and it's ready to be used with the hyper [`serve`](https://docs.rs/hyper/0.13.5/hyper/server/struct.Builder.html#method.serve)
+    /// Creates a new service with the provided router and it's ready to be used with the hyper [`serve`](https://docs.rs/hyper/0.14.4/hyper/server/struct.Builder.html#method.serve)
     /// method.
     pub fn new(mut router: Router<B, E>) -> crate::Result<RouterService<B, E>> {
         Self::init_router_with_x_powered_by_middleware(&mut router);


### PR DESCRIPTION
* Add request context section under `Data sharing` in `lib.rs`.
* Add request duration example.
* Update links and tidy up docs and readme a bit.

I've taken a liberty to trim down readme and lib.rs by removing the second paragraph and benchmarks in order for the potential users to get to the examples faster. I understand that this might be completely subjective and have no problem with dropping the changes if you like.