### PR TITLE
support for old error creation api.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,8 +38,8 @@ impl Error {
     }
     pub fn wrap<E>(e: E) -> Self
     where
-        E: std::error::Error + Send + Sync + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     {
-        Self::Wrapped(Box::new(e))
+        Self::Wrapped(e.into())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,4 +27,19 @@ pub enum Error {
 
     #[error("One of the post middlewares (with info) couldn't process the response")]
     HandlePostMiddlewareWithInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("{0}")]
+    Custom(String),
+    #[error("{0}")]
+    Wrapped(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+impl Error {
+    pub fn new(s: impl AsRef<str>) -> Self {
+        Self::Custom(s.as_ref().to_owned())
+    }
+    pub fn wrap<E>(e: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Wrapped(Box::new(e))
+    }
 }


### PR DESCRIPTION
`wrap` and `new` methods are the easiest way to create error types without creating whole new error types in ones app.
Also removing them would require a serious refactoring to old apps where routerify 1x was in use/
This pr aims to both create a smoother migration from 1x to 2x as well as simpler error handling by simply wrapping existing errors or creating ones from string which is really convenient.