### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ http = "0.2"
 regex = "1"
 lazy_static = "1"
 percent-encoding = "2"
-thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,8 @@ Run an example:
 
 * [`error_handling`](error_handling.rs) - Shows how to handle any error in `Routerify`.
 
+* [`error_handling`](error_handling_with_custom_errors.rs) - Shows how to handle any custom errors.
+
 * [`error_handling_with_request_info`](error_handling_with_request_info.rs) - Shows how to handle any error in `Routerify` based on the request information e.g. headers, method, uri etc.
 
 * [`handle_404_pages`](handle_404_pages.rs) - An example on how to handle any non-existent pages.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ Run an example:
 
 * [`error_handling`](error_handling.rs) - Shows how to handle any error in `Routerify`.
 
-* [`error_handling`](error_handling_with_custom_errors.rs) - Shows how to handle any custom errors.
+* [`error_handling_with_custom_errors`](error_handling_with_custom_errors.rs) - Shows how to handle any custom errors.
 
 * [`error_handling_with_request_info`](error_handling_with_request_info.rs) - Shows how to handle any error in `Routerify` based on the request information e.g. headers, method, uri etc.
 

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -12,9 +12,9 @@ async fn about_handler(_: Request<Body>) -> Result<Response<Body>, routerify::Er
     Ok(Response::new(Body::from("About page")))
 }
 
-// Define an error handler function which will accept the `routerify::HandleError`
+// Define an error handler function which will accept the `routerify::RouteError`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::HandleError) -> Response<Body> {
+async fn error_handler(err: routerify::RouteError) -> Response<Body> {
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
         .body(Body::from(err.to_string()))

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,38 +1,27 @@
 use hyper::{Body, Request, Response, Server, StatusCode};
 use routerify::{Router, RouterService};
-use std::io;
 use std::net::SocketAddr;
 
 // A handler for "/" page.
-async fn home_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
-    Err(io::Error::new(io::ErrorKind::Other, "Some errors"))
+async fn home_handler(_: Request<Body>) -> Result<Response<Body>, routerify::Error> {
+    Err(routerify::Error::new("Some errors"))
 }
 
 // A handler for "/about" page.
-async fn about_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
+async fn about_handler(_: Request<Body>) -> Result<Response<Body>, routerify::Error> {
     Ok(Response::new(Body::from("About page")))
 }
 
-fn format_cause_chain(err: impl std::error::Error) -> String {
-    let mut lines = vec![format!("error: {}", err)];
-    let mut source = err.source();
-    while let Some(src) = source {
-        lines.push(format!("  caused by: {}", src));
-        source = src.source();
-    }
-    lines.join("\n")
-}
-
-// Define an error handler function which will accept the `routerify::Error`
+// Define an error handler function which will accept the `routerify::HandleError`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::Error) -> Response<Body> {
+async fn error_handler(err: routerify::HandleError) -> Response<Body> {
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
-        .body(Body::from(format_cause_chain(err)))
+        .body(Body::from(err.to_string()))
         .unwrap()
 }
 
-fn router() -> Router<Body, io::Error> {
+fn router() -> Router<Body, routerify::Error> {
     // Create a router and specify the the handlers.
     Router::builder()
         .get("/", home_handler)

--- a/examples/error_handling_with_custom_errors.rs
+++ b/examples/error_handling_with_custom_errors.rs
@@ -1,0 +1,83 @@
+use hyper::{Body, Request, Response, Server, StatusCode};
+use routerify::{Router, RouterService};
+use std::fmt;
+use std::net::SocketAddr;
+
+// Define a custom error enum to model a possible API service error.
+#[derive(Debug)]
+enum ApiError {
+    #[allow(dead_code)]
+    Unauthorized,
+    Generic(String),
+}
+
+impl std::error::Error for ApiError {}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ApiError::Unauthorized => write!(f, "Unauthorized"),
+            ApiError::Generic(s) => write!(f, "Generic: {}", s),
+        }
+    }
+}
+
+// Router, handlers and middleware must use the same error type.
+// In this case it's `ApiError`.
+
+// A handler for "/" page.
+async fn home_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
+    // Simulate failure by returning `ApiError::Generic` variant.
+    Err(ApiError::Generic("Something went wrong!".into()))
+}
+
+// Define an error handler function which will accept the `routerify::HandleError`
+// and generates an appropriate response.
+async fn error_handler(err: routerify::HandleError) -> Response<Body> {
+    // Because `routerify::HandleError` is a boxed error, it must be
+    // downcasted first. Unwrap for simplicity.
+    let api_err = err.downcast::<ApiError>().unwrap();
+
+    // Now that we've got the actual error, we can handle it
+    // appropriately.
+    match api_err.as_ref() {
+        ApiError::Unauthorized => Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(Body::empty())
+            .unwrap(),
+        ApiError::Generic(s) => Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from(s.to_string()))
+            .unwrap(),
+    }
+}
+
+fn router() -> Router<Body, ApiError> {
+    // Create a router and specify the the handlers.
+    Router::builder()
+        .get("/", home_handler)
+        // Specify the error handler to handle any errors caused by
+        // a route or any middleware.
+        .err_handler(error_handler)
+        .build()
+        .unwrap()
+}
+
+#[tokio::main]
+async fn main() {
+    let router = router();
+
+    // Create a Service from the router above to handle incoming requests.
+    let service = RouterService::new(router).unwrap();
+
+    // The address on which the server will be listening.
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+
+    // Create a server by passing the created service to `.serve` method.
+    let server = Server::bind(&addr).serve(service);
+
+    println!("App is running on: {}", addr);
+    if let Err(err) = server.await {
+        eprintln!("Server error: {}", err);
+    }
+}

--- a/examples/error_handling_with_custom_errors.rs
+++ b/examples/error_handling_with_custom_errors.rs
@@ -31,10 +31,10 @@ async fn home_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
     Err(ApiError::Generic("Something went wrong!".into()))
 }
 
-// Define an error handler function which will accept the `routerify::HandleError`
+// Define an error handler function which will accept the `routerify::RouteError`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::HandleError) -> Response<Body> {
-    // Because `routerify::HandleError` is a boxed error, it must be
+async fn error_handler(err: routerify::RouteError) -> Response<Body> {
+    // Because `routerify::RouteError` is a boxed error, it must be
     // downcasted first. Unwrap for simplicity.
     let api_err = err.downcast::<ApiError>().unwrap();
 

--- a/examples/error_handling_with_request_info.rs
+++ b/examples/error_handling_with_request_info.rs
@@ -15,7 +15,7 @@ async fn about_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
 
 // Define an error handler function which will accept the `routerify::Error` and the `req_info`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::RouteError, req_info: RequestInfo) -> Response<Body> {
     eprintln!("{}", err);
 
     // Access a cookie.

--- a/examples/error_handling_with_request_info.rs
+++ b/examples/error_handling_with_request_info.rs
@@ -15,7 +15,7 @@ async fn about_handler(_: Request<Body>) -> Result<Response<Body>, io::Error> {
 
 // Define an error handler function which will accept the `routerify::Error` and the `req_info`
 // and generates an appropriate response.
-async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
     eprintln!("{}", err);
 
     // Access a cookie.

--- a/examples/share_data_and_state.rs
+++ b/examples/share_data_and_state.rs
@@ -29,7 +29,7 @@ async fn logger(req: Request<Body>) -> Result<Request<Body>, Infallible> {
 
 // Define an error handler function which will accept the `routerify::Error`
 // and the request information and generates an appropriate response.
-async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
     // You can also access the same state from error handler.
     let state = req_info.data::<State>().unwrap();
     println!("State value: {}", state.0);

--- a/examples/share_data_and_state.rs
+++ b/examples/share_data_and_state.rs
@@ -29,7 +29,7 @@ async fn logger(req: Request<Body>) -> Result<Request<Body>, Infallible> {
 
 // Define an error handler function which will accept the `routerify::Error`
 // and the request information and generates an appropriate response.
-async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::RouteError, req_info: RequestInfo) -> Response<Body> {
     // You can also access the same state from error handler.
     let state = req_info.data::<State>().unwrap();
     println!("State value: {}", state.0);

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -25,13 +25,10 @@ pub async fn home_handler(req: Request<Body>) -> Result<Response<Body>, routerif
     println!("Route Data: {}", data);
     println!("Route Data2: {:?}", req.data::<u32>());
 
-    Err(routerify::Error::HandleRequest(
-        "Error".into(),
-        "/some/fake/path".into(),
-    ))
+    Err(routerify::Error::new("Error"))
 }
 
-async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
     let data = req_info.data::<State>().map(|s| s.0).unwrap_or(0);
     println!("Error Data: {}", data);
     println!("Error Data2: {:?}", req_info.data::<u32>());

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -28,7 +28,7 @@ pub async fn home_handler(req: Request<Body>) -> Result<Response<Body>, routerif
     Err(routerify::Error::new("Error"))
 }
 
-async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::RouteError, req_info: RequestInfo) -> Response<Body> {
     let data = req_info.data::<State>().map(|s| s.0).unwrap_or(0);
     println!("Error Data: {}", data);
     println!("Error Data2: {:?}", req_info.data::<u32>());

--- a/src/data_map/scoped.rs
+++ b/src/data_map/scoped.rs
@@ -1,5 +1,6 @@
 use crate::data_map::{DataMap, SharedDataMap};
 use crate::regex_generator::generate_exact_match_regex;
+use crate::Error;
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
@@ -15,7 +16,12 @@ pub(crate) struct ScopedDataMap {
 impl ScopedDataMap {
     pub fn new<P: Into<String>>(path: P, data_map: Arc<DataMap>) -> crate::Result<ScopedDataMap> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())?;
+        let (re, _) = generate_exact_match_regex(path.as_str()).map_err(|e| {
+            Error::new(format!(
+                "Could not create an exact match regex for the scoped data map path: {}",
+                e
+            ))
+        })?;
 
         Ok(ScopedDataMap {
             path,

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 /// The error type used by the error handlers.
 pub type HandleError = Box<dyn StdError + Send + Sync + 'static>;
 
-/// The error type for simple string errors for compatibility with Routerify v1.
+/// Simple string error for compatibility with Routerify v1.
 /// Can be used in return types of handlers and middleware.
 pub struct Error {
     msg: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
 
 /// The error type used by the error handlers.
-pub type HandleError = Box<dyn StdError + Send + Sync + 'static>;
+pub type RouteError = Box<dyn StdError + Send + Sync + 'static>;
 
 /// Simple string error for compatibility with Routerify v1.
 /// Can be used in return types of handlers and middleware.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,30 +1,41 @@
-/// The error type used by the `Routerify` library.
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Couldn't decode the request path as UTF8")]
-    DecodeRequestPath(#[source] std::str::Utf8Error),
+use std::error::Error as StdError;
+use std::fmt::{self, Debug, Display, Formatter};
 
-    #[error("Couldn't create router RegexSet")]
-    CreateRouterRegexSet(#[source] regex::Error),
+/// The error type used by the error handlers.
+pub type HandleError = Box<dyn StdError + Send + Sync + 'static>;
 
-    #[error("Could not create an exact match regex for the route path: {1}")]
-    GenerateExactMatchRegex(#[source] regex::Error, String),
+/// The error type for simple string errors for compatibility with Routerify v1.
+/// Can be used in return types of handlers and middleware.
+pub struct Error {
+    msg: String,
+}
 
-    #[error("Could not create an exact match regex for the route path: {1}")]
-    GeneratePrefixMatchRegex(#[source] regex::Error, String),
+impl Error {
+    /// Creates a new error instance with the specified message.
+    pub fn new<M: Into<String>>(msg: M) -> Self {
+        Error { msg: msg.into() }
+    }
 
-    #[error("No handlers added to handle non-existent routes. Tips: Please add an '.any' route at the bottom to handle any routes.")]
-    HandleNonExistentRoute,
+    /// Converts other error type to the `routerify::Error` type.
+    pub fn wrap<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Error { msg: err.to_string() }
+    }
+}
 
-    #[error("A route was unable to handle the pre middleware request")]
-    HandlePreMiddlewareRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "routerify::Error: {}", self.msg)
+    }
+}
 
-    #[error("A route was unable to handle the request for target: {1}")]
-    HandleRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>, String),
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "routerify::Error: {}", self.msg)
+    }
+}
 
-    #[error("One of the post middlewares (without info) couldn't process the response")]
-    HandlePostMiddlewareWithoutInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-
-    #[error("One of the post middlewares (with info) couldn't process the response")]
-    HandlePostMiddlewareWithInfoRequest(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        self.msg.as_str()
+    }
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,4 @@
 use crate::types::RequestMeta;
-use crate::Error;
 use http::Extensions;
 use percent_encoding::percent_decode_str;
 
@@ -14,7 +13,7 @@ pub(crate) fn update_req_meta_in_extensions(ext: &mut Extensions, new_req_meta: 
 pub(crate) fn percent_decode_request_path(val: &str) -> crate::Result<String> {
     percent_decode_str(val)
         .decode_utf8()
-        .map_err(Error::DecodeRequestPath)
+        .map_err(Into::into)
         .map(|val| val.to_string())
 }
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,4 +1,5 @@
 use crate::types::RequestMeta;
+use crate::Error;
 use http::Extensions;
 use percent_encoding::percent_decode_str;
 
@@ -13,7 +14,7 @@ pub(crate) fn update_req_meta_in_extensions(ext: &mut Extensions, new_req_meta: 
 pub(crate) fn percent_decode_request_path(val: &str) -> crate::Result<String> {
     percent_decode_str(val)
         .decode_utf8()
-        .map_err(Into::into)
+        .map_err(|e| Error::new(format!("Couldn't decode the request path as UTF8: {}", e)).into())
         .map(|val| val.to_string())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -696,8 +696,14 @@
 //!
 //! ## Error Handling
 //!
-//! Any route or middleware could go wrong and throws an error. `Routerify` tries to add a default error handler in some cases. But, it also
-//! allow to attach a custom error handler. The error handler generates a response based on the error and the request info(optional).
+//! Any route or middleware could go wrong and throw an error. `Routerify` tries to add a default error handler in some cases. But, it also
+//! allows to attach a custom error handler. The error handler generates a response based on the error and the request info (optional).
+//!
+//! Routes and middleware may return any error type. The type must be the same for all routes, middleware and a router instance.
+//! The error is boxed into [`HandleError`](./type.HandleError.html)
+//! and propagated into an error handler. There, the original error is accessible after downcasting.
+//! See this [example](https://github.com/routerify/routerify/tree/master/examples/error_handling_with_custom_errors.rs)
+//! for handling custom errors.
 //!
 //! Here is an basic example:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! // Define an error handler function which will accept the `routerify::Error`
 //! // and the request information and generates an appropriate response.
-//! async fn error_handler(err: routerify::HandleError, _: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouteError, _: RequestInfo) -> Response<Body> {
 //!     eprintln!("{}", err);
 //!     Response::builder()
 //!         .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -517,7 +517,7 @@
 //!
 //! // Define an error handler function which will accept the `routerify::Error`
 //! // and the request information and generates an appropriate response.
-//! async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouteError, req_info: RequestInfo) -> Response<Body> {
 //!     // You can also access the same state from error handler.
 //!     let state = req_info.data::<State>().unwrap();
 //!     println!("State value: {}", state.0);
@@ -700,7 +700,7 @@
 //! allows to attach a custom error handler. The error handler generates a response based on the error and the request info (optional).
 //!
 //! Routes and middleware may return any error type. The type must be the same for all routes, middleware and a router instance.
-//! The error is boxed into [`HandleError`](./type.HandleError.html)
+//! The error is boxed into [`RouteError`](./type.RouteError.html)
 //! and propagated into an error handler. There, the original error is accessible after downcasting.
 //! See this [example](https://github.com/routerify/routerify/tree/master/examples/error_handling_with_custom_errors.rs)
 //! for handling custom errors.
@@ -714,7 +714,7 @@
 //!
 //! // The error handler will accept the thrown error in routerify::Error type and
 //! // it will have to generate a response based on the error.
-//! async fn error_handler(err: routerify::HandleError) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouteError) -> Response<Body> {
 //!     Response::builder()
 //!       .status(StatusCode::INTERNAL_SERVER_ERROR)
 //!       .body(Body::from("Something went wrong"))
@@ -745,7 +745,7 @@
 //!
 //! // The error handler will accept the thrown error and the request info and
 //! // it will generate a response.
-//! async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::RouteError, req_info: RequestInfo) -> Response<Body> {
 //!     // Now generate response based on the `err` and the `req_info`.
 //!     Response::builder()
 //!       .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -765,7 +765,7 @@
 //! # run();
 //! ```
 
-pub use self::error::{Error, HandleError};
+pub use self::error::{Error, RouteError};
 pub use self::middleware::{Middleware, PostMiddleware, PreMiddleware};
 pub use self::route::Route;
 pub use self::router::{Router, RouterBuilder};
@@ -789,4 +789,4 @@ mod service;
 mod types;
 
 /// A Result type often returned from methods that can have routerify errors.
-pub type Result<T> = std::result::Result<T, HandleError>;
+pub type Result<T> = std::result::Result<T, RouteError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! // Define an error handler function which will accept the `routerify::Error`
 //! // and the request information and generates an appropriate response.
-//! async fn error_handler(err: routerify::Error, _: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::HandleError, _: RequestInfo) -> Response<Body> {
 //!     eprintln!("{}", err);
 //!     Response::builder()
 //!         .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -517,7 +517,7 @@
 //!
 //! // Define an error handler function which will accept the `routerify::Error`
 //! // and the request information and generates an appropriate response.
-//! async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
 //!     // You can also access the same state from error handler.
 //!     let state = req_info.data::<State>().unwrap();
 //!     println!("State value: {}", state.0);
@@ -708,7 +708,7 @@
 //!
 //! // The error handler will accept the thrown error in routerify::Error type and
 //! // it will have to generate a response based on the error.
-//! async fn error_handler(err: routerify::Error) -> Response<Body> {
+//! async fn error_handler(err: routerify::HandleError) -> Response<Body> {
 //!     Response::builder()
 //!       .status(StatusCode::INTERNAL_SERVER_ERROR)
 //!       .body(Body::from("Something went wrong"))
@@ -739,7 +739,7 @@
 //!
 //! // The error handler will accept the thrown error and the request info and
 //! // it will generate a response.
-//! async fn error_handler(err: routerify::Error, req_info: RequestInfo) -> Response<Body> {
+//! async fn error_handler(err: routerify::HandleError, req_info: RequestInfo) -> Response<Body> {
 //!     // Now generate response based on the `err` and the `req_info`.
 //!     Response::builder()
 //!       .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -759,7 +759,7 @@
 //! # run();
 //! ```
 
-pub use self::error::Error;
+pub use self::error::{Error, HandleError};
 pub use self::middleware::{Middleware, PostMiddleware, PreMiddleware};
 pub use self::route::Route;
 pub use self::router::{Router, RouterBuilder};
@@ -783,4 +783,4 @@ mod service;
 mod types;
 
 /// A Result type often returned from methods that can have routerify errors.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, HandleError>;

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -1,5 +1,6 @@
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::RequestInfo;
+use crate::Error;
 use hyper::{body::HttpBody, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -45,7 +46,12 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
         scope_depth: u32,
     ) -> crate::Result<PostMiddleware<B, E>> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())?;
+        let (re, _) = generate_exact_match_regex(path.as_str()).map_err(|e| {
+            Error::new(format!(
+                "Could not create an exact match regex for the post middleware path: {}",
+                e
+            ))
+        })?;
 
         Ok(PostMiddleware {
             path,

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -1,6 +1,5 @@
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::RequestInfo;
-use crate::Error;
 use hyper::{body::HttpBody, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -140,12 +139,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
             .expect("A router can not be used after mounting into another router");
 
         match handler {
-            Handler::WithoutInfo(ref handler) => Pin::from(handler(res))
-                .await
-                .map_err(|e| Error::HandlePostMiddlewareWithoutInfoRequest(e.into())),
+            Handler::WithoutInfo(ref handler) => Pin::from(handler(res)).await.map_err(Into::into),
             Handler::WithInfo(ref handler) => Pin::from(handler(res, req_info.expect("No RequestInfo is provided")))
                 .await
-                .map_err(|e| Error::HandlePostMiddlewareWithInfoRequest(e.into())),
+                .map_err(Into::into),
         }
     }
 }

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -1,5 +1,4 @@
 use crate::regex_generator::generate_exact_match_regex;
-use crate::Error;
 use hyper::Request;
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -75,9 +74,7 @@ impl<E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static> PreMiddleware<
             .as_ref()
             .expect("A router can not be used after mounting into another router");
 
-        Pin::from(handler(req))
-            .await
-            .map_err(|e| Error::HandlePreMiddlewareRequest(e.into()))
+        Pin::from(handler(req)).await.map_err(Into::into)
     }
 }
 

--- a/src/middleware/pre.rs
+++ b/src/middleware/pre.rs
@@ -1,4 +1,5 @@
 use crate::regex_generator::generate_exact_match_regex;
+use crate::Error;
 use hyper::Request;
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -30,7 +31,12 @@ impl<E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static> PreMiddleware<
         scope_depth: u32,
     ) -> crate::Result<PreMiddleware<E>> {
         let path = path.into();
-        let (re, _) = generate_exact_match_regex(path.as_str())?;
+        let (re, _) = generate_exact_match_regex(path.as_str()).map_err(|e| {
+            Error::new(format!(
+                "Could not create an exact match regex for the pre middleware path: {}",
+                e
+            ))
+        })?;
 
         Ok(PreMiddleware {
             path,

--- a/src/regex_generator/mod.rs
+++ b/src/regex_generator/mod.rs
@@ -1,4 +1,3 @@
-use crate::Error;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -38,7 +37,7 @@ fn generate_common_regex_str(path: &str) -> (String, Vec<String>) {
 pub(crate) fn generate_exact_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
     let (common_regex_str, params) = generate_common_regex_str(path);
     let re_str = format!("{}{}{}", r"(?s)^", common_regex_str, "$");
-    let re = Regex::new(re_str.as_str()).map_err(|e| Error::GenerateExactMatchRegex(e, path.into()))?;
+    let re = Regex::new(re_str.as_str())?;
     Ok((re, params))
 }
 
@@ -46,7 +45,7 @@ pub(crate) fn generate_exact_match_regex(path: &str) -> crate::Result<(Regex, Ve
 pub(crate) fn generate_prefix_match_regex(path: &str) -> crate::Result<(Regex, Vec<String>)> {
     let (common_regex_str, params) = generate_common_regex_str(path);
     let re_str = format!("{}{}", r"(?s)^", common_regex_str);
-    let re = Regex::new(re_str.as_str()).map_err(|e| Error::GeneratePrefixMatchRegex(e, path.into()))?;
+    let re = Regex::new(re_str.as_str())?;
     Ok((re, params))
 }
 

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -1,6 +1,7 @@
 use crate::helpers;
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::{RequestMeta, RouteParams};
+use crate::Error;
 use hyper::{body::HttpBody, Method, Request, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -62,7 +63,12 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
         scope_depth: u32,
     ) -> crate::Result<Route<B, E>> {
         let path = path.into();
-        let (re, params) = generate_exact_match_regex(path.as_str())?;
+        let (re, params) = generate_exact_match_regex(path.as_str()).map_err(|e| {
+            Error::new(format!(
+                "Could not create an exact match regex for the route path: {}",
+                e
+            ))
+        })?;
 
         Ok(Route {
             path,

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -1,7 +1,6 @@
 use crate::helpers;
 use crate::regex_generator::generate_exact_match_regex;
 use crate::types::{RequestMeta, RouteParams};
-use crate::Error;
 use hyper::{body::HttpBody, Method, Request, Response};
 use regex::Regex;
 use std::fmt::{self, Debug, Formatter};
@@ -97,9 +96,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
             .as_ref()
             .expect("A router can not be used after mounting into another router");
 
-        Pin::from(handler(req))
-            .await
-            .map_err(|e| Error::HandleRequest(e.into(), target_path.into()))
+        Pin::from(handler(req)).await.map_err(Into::into)
     }
 
     fn push_req_meta(&self, target_path: &str, req: &mut Request<hyper::Body>) {

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -83,7 +83,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
                         .collect::<Vec<crate::Result<ScopedDataMap>>>()
                 })
                 .flatten()
-                .collect::<Result<Vec<ScopedDataMap>, crate::HandleError>>()?;
+                .collect::<Result<Vec<ScopedDataMap>, crate::RouteError>>()?;
 
             Ok(Router::new(
                 inner.pre_middlewares,
@@ -700,10 +700,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     /// for more info.
     pub fn err_handler<H, R>(self, handler: H) -> Self
     where
-        H: Fn(crate::HandleError) -> R + Send + Sync + 'static,
+        H: Fn(crate::RouteError) -> R + Send + Sync + 'static,
         R: Future<Output = Response<B>> + Send + 'static,
     {
-        let handler: ErrHandlerWithoutInfo<B> = Box::new(move |err: crate::HandleError| Box::new(handler(err)));
+        let handler: ErrHandlerWithoutInfo<B> = Box::new(move |err: crate::RouteError| Box::new(handler(err)));
 
         self.and_then(move |mut inner| {
             inner.err_handler = Some(ErrHandler::WithoutInfo(handler));
@@ -719,11 +719,11 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     /// for more info.
     pub fn err_handler_with_info<H, R>(self, handler: H) -> Self
     where
-        H: Fn(crate::HandleError, RequestInfo) -> R + Send + Sync + 'static,
+        H: Fn(crate::RouteError, RequestInfo) -> R + Send + Sync + 'static,
         R: Future<Output = Response<B>> + Send + 'static,
     {
         let handler: ErrHandlerWithInfo<B> =
-            Box::new(move |err: crate::HandleError, req_info: RequestInfo| Box::new(handler(err, req_info)));
+            Box::new(move |err: crate::RouteError, req_info: RequestInfo| Box::new(handler(err, req_info)));
 
         self.and_then(move |mut inner| {
             inner.err_handler = Some(ErrHandler::WithInfo(handler));

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -83,7 +83,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
                         .collect::<Vec<crate::Result<ScopedDataMap>>>()
                 })
                 .flatten()
-                .collect::<Result<Vec<ScopedDataMap>, crate::Error>>()?;
+                .collect::<Result<Vec<ScopedDataMap>, crate::HandleError>>()?;
 
             Ok(Router::new(
                 inner.pre_middlewares,
@@ -700,10 +700,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     /// for more info.
     pub fn err_handler<H, R>(self, handler: H) -> Self
     where
-        H: Fn(crate::Error) -> R + Send + Sync + 'static,
+        H: Fn(crate::HandleError) -> R + Send + Sync + 'static,
         R: Future<Output = Response<B>> + Send + 'static,
     {
-        let handler: ErrHandlerWithoutInfo<B> = Box::new(move |err: crate::Error| Box::new(handler(err)));
+        let handler: ErrHandlerWithoutInfo<B> = Box::new(move |err: crate::HandleError| Box::new(handler(err)));
 
         self.and_then(move |mut inner| {
             inner.err_handler = Some(ErrHandler::WithoutInfo(handler));
@@ -719,11 +719,11 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     /// for more info.
     pub fn err_handler_with_info<H, R>(self, handler: H) -> Self
     where
-        H: Fn(crate::Error, RequestInfo) -> R + Send + Sync + 'static,
+        H: Fn(crate::HandleError, RequestInfo) -> R + Send + Sync + 'static,
         R: Future<Output = Response<B>> + Send + 'static,
     {
         let handler: ErrHandlerWithInfo<B> =
-            Box::new(move |err: crate::Error, req_info: RequestInfo| Box::new(handler(err, req_info)));
+            Box::new(move |err: crate::HandleError, req_info: RequestInfo| Box::new(handler(err, req_info)));
 
         self.and_then(move |mut inner| {
             inner.err_handler = Some(ErrHandler::WithInfo(handler));

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -3,6 +3,7 @@ use crate::data_map::ScopedDataMap;
 use crate::middleware::{PostMiddleware, PreMiddleware};
 use crate::route::Route;
 use crate::types::RequestInfo;
+use crate::Error;
 use crate::RouteError;
 use hyper::{
     body::HttpBody,
@@ -123,7 +124,8 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
             .chain(self.post_middlewares.iter().map(|m| m.regex.as_str()))
             .chain(self.scoped_data_maps.iter().map(|d| d.regex.as_str()));
 
-        self.regex_set = Some(RegexSet::new(regex_iter)?);
+        self.regex_set =
+            Some(RegexSet::new(regex_iter).map_err(|e| Error::new(format!("Couldn't create router RegexSet: {}", e)))?);
 
         Ok(())
     }

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -89,7 +89,6 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
             router: Arc::from(router),
         })
     }
-
     pub fn build(&mut self, remote_addr: SocketAddr) -> RequestService<B, E> {
         RequestService {
             router: self.router.clone(),

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -17,7 +17,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     Service<Request<hyper::Body>> for RequestService<B, E>
 {
     type Response = Response<B>;
-    type Error = crate::HandleError;
+    type Error = crate::RouteError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -100,7 +100,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
 
 #[cfg(test)]
 mod tests {
-    use crate::{Error, HandleError, RequestServiceBuilder, Router};
+    use crate::{Error, RouteError, RequestServiceBuilder, Router};
     use futures::future::poll_fn;
     use http::Method;
     use hyper::service::Service;
@@ -124,7 +124,7 @@ mod tests {
             .unwrap();
         let mut builder = RequestServiceBuilder::new(router).unwrap();
         let mut service = builder.build(remote_addr);
-        poll_fn(|ctx| -> Poll<Result<(), HandleError>> { service.poll_ready(ctx) })
+        poll_fn(|ctx| -> Poll<Result<(), RouteError>> { service.poll_ready(ctx) })
             .await
             .expect("request service is not ready");
         let resp: Response<hyper::body::Body> = service.call(req).await.unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 use self::support::{into_text, serve};
 use hyper::{Body, Client, Request, Response, StatusCode};
 use routerify::prelude::RequestExt;
-use routerify::{Middleware, RequestInfo, Router};
+use routerify::{HandleError, Middleware, RequestInfo, Router};
 use std::io;
 use std::sync::{Arc, Mutex};
 
@@ -12,6 +12,7 @@ async fn can_perform_simple_get_request() {
     const RESPONSE_TEXT: &str = "Hello world";
     let router: Router<Body, routerify::Error> = Router::builder()
         .get("/", |_| async move { Ok(Response::new(RESPONSE_TEXT.into())) })
+        .err_handler(|_: HandleError| async move { todo!() })
         .build()
         .unwrap();
     let serve = serve(router).await;
@@ -36,6 +37,7 @@ async fn can_perform_simple_get_request_boxed_error() {
     type BoxedError = Box<dyn std::error::Error + Sync + Send + 'static>;
     let router: Router<Body, BoxedError> = Router::builder()
         .get("/", |_| async move { Ok(Response::new(RESPONSE_TEXT.into())) })
+        .err_handler(|_: HandleError| async move { todo!() })
         .build()
         .unwrap();
     let serve = serve(router).await;


### PR DESCRIPTION
This PR is the result of discussing https://github.com/routerify/routerify/pull/55.

It splits error handling into two parts:
1. Error handlers `err_handler()` and `err_handler_with_req_info()` get their own parameter type `RouteError`. It's a simple boxed error whose **only** job is to propagate user-defined errors from handlers and middleware to the error handler.
2. Simple string-based `routerify::Error` is brought back for compatibility with the existing v1 code. It may be used in return types for handlers/middleware/router, but it's **not** used as an input error type in the error handlers anymore. To be honest, it should not be used at all, because it's 2021 and it's Rust and why would you base your error logic on parsing strings. But oh well...

Here's a demonstration from a new example:

```rust
// Define a custom error enum to model a possible API service error.
#[derive(Debug)]
enum ApiError {
    #[allow(dead_code)]
    Unauthorized,
    Generic(String),
}
impl std::error::Error for ApiError {}
impl fmt::Display for ApiError {
    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
        match self {
            ApiError::Unauthorized => write!(f, "Unauthorized"),
            ApiError::Generic(s) => write!(f, "Generic: {}", s),
        }
    }
}

// Router, handlers and middleware must use the same error type.
// In this case it's `ApiError`.

// A handler for "/" page.
async fn home_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
    // Simulate failure by returning `ApiError::Generic` variant.
    Err(ApiError::Generic("Something went wrong!".into()))
}

// Define an error handler function which will accept the `routerify::RouteError`
// and generates an appropriate response.
async fn error_handler(err: routerify::RouteError) -> Response<Body> {
    // Because `routerify::RouteError` is a boxed error, it must be
    // downcasted first. Unwrap for simplicity.
    let api_err = err.downcast::<ApiError>().unwrap();

    // Now that we've got the actual error, we can handle it
    // appropriately.
    match api_err.as_ref() {
        ApiError::Unauthorized => Response::builder()
            .status(StatusCode::UNAUTHORIZED)
            .body(Body::empty())
            .unwrap(),
        ApiError::Generic(s) => Response::builder()
            .status(StatusCode::INTERNAL_SERVER_ERROR)
            .body(Body::from(s.to_string()))
            .unwrap(),
    }
}

fn router() -> Router<Body, ApiError> {
    Router::builder()
        .get("/", home_handler)
        .err_handler(error_handler)
        .build()
        .unwrap()
}

```

I believe this implementation is good enough to move forward with v2. It's simple, and in my opinion an improvement compared to the existing enum generated with `thiserror`:
1. We always `.unwrap()` at the end of building, which means we do not really care about the errors generated by the builder.
2. I see little point in distinguishing between handlers, pre and post middleware errors. Proper error handling logic should be modeled by a custom enum anyway, and with a simple `err: RouteError` we can just downcast and get right to the matching, instead of having one more top-level matching between `HandlePreMiddlewareRequest `, `HandleRequest`, `HandlePostMiddlewareWithoutInfoRequest ` and `HandlePostMiddlewareWithInfoRequest `.

I also have to admit that this is not the best possible implementation. Since we've already got the generic error type parameter `E`, it would be really cool to not have to introduce `RouteError` at all. Instead, using generics, we could simply state that whatever error type was used for the router/handlers/middleware, automagically becomes the error type of the handlers  - `err_handler(err: E)`. But that would require some restructuring of the code, specifically when handling not found and maybe other places, that I'm not willing to do at the moment.