### PR TITLE
Scoped middleware should not be applied to unscoped routes with the same prefix

### DIFF
--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -572,6 +572,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
                     .handler
                     .take()
                     .expect("No handler found in one of the pre-middlewares"),
+                pre_middleware.scope_depth + 1,
             );
             builder = builder.and_then(move |mut inner| {
                 inner.pre_middlewares.push(new_pre_middleware?);
@@ -584,6 +585,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
                 format!("{}{}", path.as_str(), route.path.as_str()),
                 route.methods.clone(),
                 route.handler.take().expect("No handler found in one of the routes"),
+                route.scope_depth + 1,
             );
             builder = builder.and_then(move |mut inner| {
                 inner.routes.push(new_route?);
@@ -598,6 +600,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
                     .handler
                     .take()
                     .expect("No handler found in one of the post-middlewares"),
+                post_middleware.scope_depth + 1,
             );
             builder = builder.and_then(move |mut inner| {
                 inner.post_middlewares.push(new_post_middleware?);


### PR DESCRIPTION
Fixes https://github.com/routerify/routerify/issues/58.

* Introduce scope depth in `Route`, `PreMiddleware` and `PostMiddleware`.
* When integrating a scoped router into the parent, bump the depth of the scoped routes and middleware.
* In `Router::process()` do not execute middleware whose depth is bigger than the depth of a matched route. Take care to exclude catch-all "/*" route from the depth check - when no user-provided route is matched, **all** middleware in **all** scopes with the target prefix should be executed.