### PR TITLE
Fix processing flow when pre middleware fails

### DIFF
--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -52,16 +52,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
 
             req.extensions_mut().insert(context);
 
-            match router.process(target_path.as_str(), req, req_info.clone()).await {
-                Ok(resp) => crate::Result::Ok(resp),
-                Err(err) => {
-                    if let Some(ref err_handler) = router.err_handler {
-                        crate::Result::Ok(err_handler.execute(err, req_info.clone()).await)
-                    } else {
-                        crate::Result::Err(err)
-                    }
-                }
-            }
+            router.process(target_path.as_str(), req, req_info.clone()).await
         };
 
         Box::pin(fut)


### PR DESCRIPTION
When pre middleware fails, correctly propagate router `data` to the error handler and then execute post middleware. Currently none of this happens - when pre middleware fails, the execution goes to the error handler **without** `data` set and the generated error response is sent back to the client **without** executing post middleware.