### PR TITLE
Avoid boxing the router service's response future

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Routerify's core features:
 
 To generate a quick server app using [Routerify](https://github.com/routerify/routerify) and [hyper](https://hyper.rs/), please check out [hyper-routerify-server-template](https://github.com/routerify/hyper-routerify-server-template).
 
+*Compiler support: requires rustc 1.48+*
+
 ## Benchmarks
 
 | Framework      | Language    | Requests/sec |

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -2,8 +2,7 @@ use crate::router::Router;
 use crate::service::request_service::{RequestService, RequestServiceBuilder};
 use hyper::{body::HttpBody, server::conn::AddrStream, service::Service};
 use std::convert::Infallible;
-use std::future::Future;
-use std::pin::Pin;
+use std::future::{ready, Ready};
 use std::task::{Context, Poll};
 
 /// A [`Service`](https://docs.rs/hyper/0.14.4/hyper/service/trait.Service.html) to process incoming requests.
@@ -74,7 +73,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
 {
     type Response = RequestService<B, E>;
     type Error = Infallible;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -83,8 +82,6 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     fn call(&mut self, conn: &AddrStream) -> Self::Future {
         let req_service = self.builder.build(conn.remote_addr());
 
-        let fut = async move { Ok(req_service) };
-
-        Box::pin(fut)
+        ready(Ok(req_service))
     }
 }


### PR DESCRIPTION
Minor change skipping an allocation when handling a new connection, since there was no work done in the async method we can replace it with an instance of `std::future::Ready` which returns a value the next time it is polled.

This method was introduce in 1.48.0, if this project aims at a longer backwards compatibility window, an equivalent struct exists in the `futures` crate.