### PR TITLE
Update error_handler to use new routerify::RouteError

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ async fn logger(req: Request<Body>) -> Result<Request<Body>, Infallible> {
 
 // Define an error handler function which will accept the `routerify::Error`
 // and the request information and generates an appropriate response.
-async fn error_handler(err: routerify::Error, _: RequestInfo) -> Response<Body> {
+async fn error_handler(err: routerify::RouteError, _: RequestInfo) -> Response<Body> {
     eprintln!("{}", err);
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Description

The current example for the `error_handler` in the README would give me the following error:

```
error[E0631]: type mismatch in function arguments
   --> src/main.rs:111:32
    |
77  | async fn error_handler(err: routerify::Error, _: RequestInfo) -> Response<Body> {
    | ------------------------------------------------------------------------------- found signature of `fn(routerify::Error, RequestInfo) -> _`
...
111 |         .err_handler_with_info(error_handler)
    |                                ^^^^^^^^^^^^^ expected signature of `fn(Box<(dyn std::error::Error + Send + Sync + 'static)>, RequestInfo) -> _`
```

It seems, from the [examples](https://github.com/routerify/routerify/blob/804abea1addd815de8e6fcb63b2245df51da0e08/examples/error_handling_with_request_info.rs#L18) that this should instead be `routerify::RouteError`.

After changing to the new `RouteError` type, everything compiles :)