### PR TITLE
Require only a shared reference when building a RequestService via the Builder

### DIFF
--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -83,7 +83,7 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
         })
     }
 
-    pub fn build(&mut self, remote_addr: SocketAddr) -> RequestService<B, E> {
+    pub fn build(&self, remote_addr: SocketAddr) -> RequestService<B, E> {
         RequestService {
             router: self.router.clone(),
             remote_addr,


### PR DESCRIPTION
I'm trying to create a static `RequestServiceBuilder` so that a `RequestService` can be initialized within an entrypoint for each request, but can re-use an already initialized `Router`:

(pseudo Rust)
```rust
lazy_static! {
    static ref BUILDER: RequestServiceBuilder<B, E> = {
        let router: routerify::Router<B, E> = build_router();
        RequestServiceBuilder::new(router).unwrap();
    };
}

/// AWS Lambda entrypoint
async fn entrypoint(req: Request, _ctx: Context) -> Result<impl IntoResponse, HandlerError> {
    let remote_addr = get_remote_addr(&req);
    let mut service = BUILDER.build(remote_addr);
    // ..
}
```

After initializing a `RequestServiceBuilder`, the entrypoint function cannot call `BUILDER.build(remote_addr)` because of the method requiring a mutable borrow of a static variable. This PR replaces this with `&self` to allow usage of the static variable.

Preferably, we can release this soon as `2.0.2`.