### PR TITLE
Remove X-POWERED-BY header

### DIFF
--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -1,8 +1,5 @@
 use hyper::Method;
 
-pub(crate) const HEADER_NAME_X_POWERED_BY: &str = "x-powered-by";
-pub(crate) const HEADER_VALUE_X_POWERED_BY: &str = concat!("Routerify v", env!("CARGO_PKG_VERSION"));
-
 pub(crate) const ALL_POSSIBLE_HTTP_METHODS: [Method; 9] = [
     Method::GET,
     Method::POST,

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -5,11 +5,7 @@ use crate::route::Route;
 use crate::types::RequestInfo;
 use crate::Error;
 use crate::RouteError;
-use hyper::{
-    body::HttpBody,
-    header::{self, HeaderValue},
-    Method, Request, Response, StatusCode,
-};
+use hyper::{body::HttpBody, header, Method, Request, Response, StatusCode};
 use regex::RegexSet;
 use std::any::Any;
 use std::fmt::{self, Debug, Formatter};
@@ -144,19 +140,6 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
         }
 
         self.should_gen_req_info = Some(false);
-    }
-
-    pub(crate) fn init_x_powered_by_middleware(&mut self) {
-        let x_powered_by_post_middleware = PostMiddleware::new("/*", |mut res| async move {
-            res.headers_mut().insert(
-                constants::HEADER_NAME_X_POWERED_BY,
-                HeaderValue::from_static(constants::HEADER_VALUE_X_POWERED_BY),
-            );
-            Ok(res)
-        })
-        .unwrap();
-
-        self.post_middlewares.insert(0, x_powered_by_post_middleware);
     }
 
     // pub(crate) fn init_keep_alive_middleware(&mut self) {

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -69,7 +69,6 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     RequestServiceBuilder<B, E>
 {
     pub fn new(mut router: Router<B, E>) -> crate::Result<Self> {
-        router.init_x_powered_by_middleware();
         // router.init_keep_alive_middleware();
 
         router.init_global_options_route();


### PR DESCRIPTION
This removes the X-POWERED-BY header middleware altogether, as discussed in https://github.com/routerify/routerify/issues/90, mainly for improved security.