### PR TITLE
Update aws_lambda to use the latest aws-lambda-rust-runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ tokio = { version = "1", features = ["full"] }
 futures = { version = "0.3" }
 
 # For the AWS Lambda example
-aws_lambda_events = "0.4.0"
-lambda_http = { package = "netlify_lambda_http", version = "0.2.0" }
+lambda_http = { version = "0.4", default-features = false }
 slog = "2"
-sloggers = "1.0"
+sloggers = "2"
 url = "2"

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -25,8 +25,10 @@ pub enum Middleware<B, E> {
     Post(PostMiddleware<B, E>),
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    Middleware<B, E>
+impl<B, E> Middleware<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     /// Creates a pre middleware with a handler at the `/*` path.
     ///

--- a/src/middleware/post.rs
+++ b/src/middleware/post.rs
@@ -37,8 +37,10 @@ pub(crate) enum Handler<B, E> {
     WithInfo(HandlerWithInfo<B, E>),
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    PostMiddleware<B, E>
+impl<B, E> PostMiddleware<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -55,7 +55,11 @@ pub struct Route<B, E> {
     pub(crate) scope_depth: u32,
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static> Route<B, E> {
+impl<B, E> Route<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+{
     pub(crate) fn new_with_boxed_handler<P: Into<String>>(
         path: P,
         methods: Vec<Method>,

--- a/src/router/builder.rs
+++ b/src/router/builder.rs
@@ -62,8 +62,10 @@ struct BuilderInner<B, E> {
     err_handler: Option<ErrHandler<B>>,
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    RouterBuilder<B, E>
+impl<B, E> RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     /// Creates a new `RouterBuilder` instance with default options.
     pub fn new() -> RouterBuilder<B, E> {
@@ -105,8 +107,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     }
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    RouterBuilder<B, E>
+impl<B, E> RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     /// Adds a new route with `GET` method and the handler at the specified path.
     ///
@@ -636,8 +640,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     }
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    RouterBuilder<B, E>
+impl<B, E> RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     /// Adds a single middleware. A pre middleware can be created by [`Middleware::pre`](./enum.Middleware.html#method.pre) method and a post
     /// middleware can be created by [`Middleware::post`](./enum.Middleware.html#method.post) method.
@@ -732,8 +738,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     }
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static> Default
-    for RouterBuilder<B, E>
+impl<B, E> Default for RouterBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     fn default() -> RouterBuilder<B, E> {
         RouterBuilder {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -92,7 +92,11 @@ impl<B: HttpBody + Send + Sync + 'static> ErrHandler<B> {
     }
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static> Router<B, E> {
+impl<B, E> Router<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+{
     pub(crate) fn new(
         pre_middlewares: Vec<PreMiddleware<E>>,
         routes: Vec<Route<B, E>>,

--- a/src/service/request_service.rs
+++ b/src/service/request_service.rs
@@ -1,21 +1,25 @@
-use crate::helpers;
-use crate::router::Router;
-use crate::types::{RequestContext, RequestInfo, RequestMeta};
-use crate::Error;
-use hyper::{body::HttpBody, service::Service, Request, Response};
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use hyper::{body::HttpBody, service::Service, Request, Response};
+
+use crate::helpers;
+use crate::router::Router;
+use crate::types::{RequestContext, RequestInfo, RequestMeta};
+use crate::Error;
+
 pub struct RequestService<B, E> {
     pub(crate) router: Arc<Router<B, E>>,
     pub(crate) remote_addr: SocketAddr,
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    Service<Request<hyper::Body>> for RequestService<B, E>
+impl<B, E> Service<Request<hyper::Body>> for RequestService<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     type Response = Response<B>;
     type Error = crate::RouteError;
@@ -65,8 +69,10 @@ pub struct RequestServiceBuilder<B, E> {
     router: Arc<Router<B, E>>,
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    RequestServiceBuilder<B, E>
+impl<B, E> RequestServiceBuilder<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     pub fn new(mut router: Router<B, E>) -> crate::Result<Self> {
         // router.init_keep_alive_middleware();

--- a/src/service/router_service.rs
+++ b/src/service/router_service.rs
@@ -57,8 +57,10 @@ pub struct RouterService<B, E> {
     builder: RequestServiceBuilder<B, E>,
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    RouterService<B, E>
+impl<B, E> RouterService<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     /// Creates a new service with the provided router and it's ready to be used with the hyper [`serve`](https://docs.rs/hyper/0.14.4/hyper/server/struct.Builder.html#method.serve)
     /// method.
@@ -68,8 +70,10 @@ impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Se
     }
 }
 
-impl<B: HttpBody + Send + Sync + 'static, E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static>
-    Service<&AddrStream> for RouterService<B, E>
+impl<B, E> Service<&AddrStream> for RouterService<B, E>
+where
+    B: HttpBody + Send + Sync + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
     type Response = RequestService<B, E>;
     type Error = Infallible;


### PR DESCRIPTION
The changes in this short PR are detailed below. I'm just looking for a quick sanity check before merging.

### test: use [official runtime](https://github.com/awslabs/aws-sdk-rust) in aws_lambda example 

This MR replaces the fork of [aws-lambda-rust-runtime](https://github.com/awslabs/aws-lambda-rust-runtime) in `examples/aws_lambda.rs` to use the latest release of the official AWS Lambda runtime (0.4), now that is has an active maintainer.

### style: move complicated trait bounds to where-clauses 

This is a coincidental style-change to move the `<B, E>` trait bounds of `impl` blocks into its own `where` clause. It would be nice if these type signatures could be more easily shared and re-used, instead of the bounds being copied everywhere, but this can be a separate PR.