### PR TITLE
Use minimal set of dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,15 @@ all-features = true
 features = ["all"]
 
 [features]
-default = []
+default = ["hyper-http1"]
 all = []
+hyper-http1 = ["hyper/http1"]
+hyper-http2 = ["hyper/http2"]
 
 [dependencies]
-hyper = { version = "0.14", default-features = false, features = ["full"] }
+hyper = { version = "0.14", default-features = false, features = ["server", "tcp"] }
 http = "0.2"
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std"] }
 lazy_static = "1"
 percent-encoding = "2"
 


### PR DESCRIPTION
Remove dependency features that we aren't using.  As part of this a new feature is added for the hyper http1 or http2 choice and the regex features are trimmed down.  This reduces a basic example from needing 66 to 54 dependencies.

I do know of one way this change could break code that uses this library.  Suppose that a program using routerify has the regex crate listed as a dependency but has its `unicode` feature disabled.  Since they are compiling against routerify which had this feature enabled they would be able to use functionality from this feature.  If we merge this pull request, for this example there code will still compile but panic at runtime, they would need to add the regex `unicode` feature to their crate:
```
$ ./target/debug/examples/regex
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    \p{Letter}
    ^^^^^^^^^^
error: Unicode property not found
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
)', src/routerify/examples/regex.rs:79:40
```

This type of error is a runtime error in the regex crate, but if there are functions that only exist when the feature is enabled then I expect it would be a compile time error.

related #97