### PR TITLE
Make RouterService a optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 features = ["all"]
 
 [features]
-default = ["hyper-http1", "hyper/tcp"]
+default = ["hyper-http1", "router-service"]
 all = ["hyper-http1", "hyper-http2"]
 hyper-http1 = ["hyper/http1"]
 hyper-http2 = ["hyper/http2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,59 @@ lambda_http = { package = "netlify_lambda_http", version = "0.2.0" }
 slog = "2"
 sloggers = "1.0"
 url = "2"
+
+[[example]]
+name = "error_handling_with_custom_errors"
+required-features = ["router-service"]
+
+[[example]]
+name = "error_handling_with_request_info"
+required-features = ["router-service"]
+
+[[example]]
+name = "error_handling"
+required-features = ["router-service"]
+
+[[example]]
+name = "handle_404_pages"
+required-features = ["router-service"]
+
+[[example]]
+name = "middleware"
+required-features = ["router-service"]
+
+[[example]]
+name = "request_duration"
+required-features = ["router-service"]
+
+[[example]]
+name = "route_parameters"
+required-features = ["router-service"]
+
+[[example]]
+name = "scoped_router"
+required-features = ["router-service"]
+
+[[example]]
+name = "share_data_and_state"
+required-features = ["router-service"]
+
+[[example]]
+name = "simple_example"
+required-features = ["router-service"]
+
+[[example]]
+name = "test_with_heavy_loads"
+required-features = ["router-service"]
+
+[[example]]
+name = "test"
+required-features = ["router-service"]
+
+[[example]]
+name = "test2"
+required-features = ["router-service"]
+
+[[test]]
+name = "integration"
+required-features = ["router-service"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ name = "simple_example"
 required-features = ["router-service"]
 
 [[example]]
-name = "test_with_heavy_loads"
+name = "test-with-heavy-loads"
 required-features = ["router-service"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hyper-http1 = ["hyper/http1"]
 hyper-http2 = ["hyper/http2"]
 
 [dependencies]
-hyper = { version = "0.14", default-features = false, features = ["server", "tcp"] }
+hyper = { version = "0.14", default-features = false, features = ["server"] }
 http = "0.2"
 regex = { version = "1", default-features = false, features = ["std"] }
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ all-features = true
 features = ["all"]
 
 [features]
-default = ["hyper-http1"]
+default = ["hyper-http1", "hyper/tcp"]
 all = ["hyper-http1", "hyper-http2"]
 hyper-http1 = ["hyper/http1"]
 hyper-http2 = ["hyper/http2"]
+router-service = ["hyper/tcp"]
 
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["server"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,6 +772,7 @@ pub use self::router::{Router, RouterBuilder};
 #[doc(hidden)]
 pub use self::service::RequestService;
 pub use self::service::RequestServiceBuilder;
+#[cfg(feature = "router-service")]
 pub use self::service::RouterService;
 pub use self::types::{RequestInfo, RouteParams};
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,7 @@
 pub use request_service::{RequestService, RequestServiceBuilder};
+#[cfg(feature = "router-service")]
 pub use router_service::RouterService;
 
 mod request_service;
+#[cfg(feature = "router-service")]
 mod router_service;


### PR DESCRIPTION
I try to use `routerify` without `crate mio` which is a dependency of `tokio` and `hyper` with the `tcp` feature. On my `esp32c3` `mio` is not patched, so I have to avoid this dependency. Now, I use `routerify` with its `RequestServiceBuilder`.